### PR TITLE
Add Steam Networking

### DIFF
--- a/descriptions/SDK.SteamNetworking.md
+++ b/descriptions/SDK.SteamNetworking.md
@@ -1,0 +1,1 @@
+[SteamNetworkingSockets](https://partner.steamgames.com/doc/api/ISteamNetworkingSockets) is a basic transport layer for games which can use of Steam features like the Steam network and the Steam Datagram Relay.

--- a/rules.ini
+++ b/rules.ini
@@ -108,5 +108,5 @@ EpicOnlineServices = (?:^|/)(?:lib)?eossdk
 NVIDIA_Ansel = (?:^|/)AnselSDK(?:32|64)\.dll$
 NVIDIA_DLSS = (?:^|/)nvngx_dlss\.dll$
 SDL[] = (?:^|/)sdl2?\.dll$
-SteamNetworking = (?:^|/)(?:stun_)?steamnetworking(?:sockets)?\.(?:dylib|dll|so)$
+SteamNetworking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 NodeJS[] = (?:^|/)node\.dll$

--- a/rules.ini
+++ b/rules.ini
@@ -108,4 +108,5 @@ EpicOnlineServices = (?:^|/)(?:lib)?eossdk
 NVIDIA_Ansel = (?:^|/)AnselSDK(?:32|64)\.dll$
 NVIDIA_DLSS = (?:^|/)nvngx_dlss\.dll$
 SDL[] = (?:^|/)sdl2?\.dll$
+SteamNetworking = (?:^|/)(?:stun_)steamnetworking(?:sockets).(?:dylib|dll|so)$
 NodeJS[] = (?:^|/)node\.dll$

--- a/rules.ini
+++ b/rules.ini
@@ -108,5 +108,5 @@ EpicOnlineServices = (?:^|/)(?:lib)?eossdk
 NVIDIA_Ansel = (?:^|/)AnselSDK(?:32|64)\.dll$
 NVIDIA_DLSS = (?:^|/)nvngx_dlss\.dll$
 SDL[] = (?:^|/)sdl2?\.dll$
-SteamNetworking = (?:^|/)(?:stun_|)steamnetworking(?:sockets)\.(?:dylib|dll|so)$
+SteamNetworking = (?:^|/)(?:stun_)?steamnetworking(?:sockets)?\.(?:dylib|dll|so)$
 NodeJS[] = (?:^|/)node\.dll$

--- a/rules.ini
+++ b/rules.ini
@@ -108,5 +108,5 @@ EpicOnlineServices = (?:^|/)(?:lib)?eossdk
 NVIDIA_Ansel = (?:^|/)AnselSDK(?:32|64)\.dll$
 NVIDIA_DLSS = (?:^|/)nvngx_dlss\.dll$
 SDL[] = (?:^|/)sdl2?\.dll$
-SteamNetworking = (?:^|/)(?:stun_)steamnetworking(?:sockets).(?:dylib|dll|so)$
+SteamNetworking = (?:^|/)(?:stun_|)steamnetworking(?:sockets)\.(?:dylib|dll|so)$
 NodeJS[] = (?:^|/)node\.dll$

--- a/tests/types/SDK.SteamNetworking.txt
+++ b/tests/types/SDK.SteamNetworking.txt
@@ -1,0 +1,3 @@
+bin/x64/steamnetworkingsockets.dll
+steamnetworkingsockets.dll
+stun_steamnetworking.dll

--- a/tests/types/SDK.SteamNetworking.txt
+++ b/tests/types/SDK.SteamNetworking.txt
@@ -1,3 +1,3 @@
 bin/x64/steamnetworkingsockets.dll
 steamnetworkingsockets.dll
-stun_steamnetworking.dll
+libsteamnetworkingsockets.so

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -355,3 +355,5 @@ StandalonePlayerLocalizablexstrings
 VisionaireConfigurationToolxexe
 lovexdll
 AGIDATAxOVL
+steamnet.dll
+bin/x64/steamnetworkingsockets.sooooo


### PR DESCRIPTION
`(?:^|/)(?:stun_)steamnetworking(?:sockets).(?:dylib|dll|so)$`
The stun part is there due to [Battlerite](https://steamdb.info/app/504370/) having it, i'm not sure if any other game has a modified lib name