### PR TITLE
Add Steam Audio

### DIFF
--- a/descriptions/SDK.Steam_Audio.md
+++ b/descriptions/SDK.Steam_Audio.md
@@ -1,0 +1,1 @@
+[Steam Audio](https://valvesoftware.github.io/steam-audio/downloads.html) is a cross-platform software toolkit for spatial audio. It can be used to add rich, immersive positional and environmental audio effects to games and VR/AR apps.

--- a/rules.ini
+++ b/rules.ini
@@ -108,4 +108,5 @@ EpicOnlineServices = (?:^|/)(?:lib)?eossdk
 NVIDIA_Ansel = (?:^|/)AnselSDK(?:32|64)\.dll$
 NVIDIA_DLSS = (?:^|/)nvngx_dlss\.dll$
 SDL[] = (?:^|/)sdl2?\.dll$
+Steam_Audio = (?:^|/)(?:lib)?steamaudio\.(?:dylib|dll|so)
 NodeJS[] = (?:^|/)node\.dll$

--- a/rules.ini
+++ b/rules.ini
@@ -108,5 +108,5 @@ EpicOnlineServices = (?:^|/)(?:lib)?eossdk
 NVIDIA_Ansel = (?:^|/)AnselSDK(?:32|64)\.dll$
 NVIDIA_DLSS = (?:^|/)nvngx_dlss\.dll$
 SDL[] = (?:^|/)sdl2?\.dll$
-Steam_Audio = (?:^|/)(?:lib)?steamaudio\.(?:dylib|dll|so)
+Steam_Audio = (?:^|/)(?:lib)?steamaudio\.(?:dylib|dll|so)$
 NodeJS[] = (?:^|/)node\.dll$

--- a/tests/types/SDK.Steam_Audio.txt
+++ b/tests/types/SDK.Steam_Audio.txt
@@ -1,0 +1,3 @@
+game/bin/win64/steamaudio.dll
+game/bin/linuxsteamrt64/libsteamaudio.so
+SteamAudio.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -355,3 +355,5 @@ StandalonePlayerLocalizablexstrings
 VisionaireConfigurationToolxexe
 lovexdll
 AGIDATAxOVL
+game/bin/linuxsteamrt64/libsteamaudio.soooooo
+SteamAudiooooo.dll


### PR DESCRIPTION
`(?:^|/)(?:lib)?steamaudio\.(?:dylib|dll|so)`
From my installed game, i didn't find any game with a mac version that had steam audio but i'll futur proof and add `dylib`
Sadly, i don't think there's way to detect Steam Audio if it's used with the fmod sound engine integration because they call the lib `phonon.dll` and i think that, from my small search, this name is not specific to Steam Audio, so using it might cause false positive