### PR TITLE
Add support for Defold game engine

### DIFF
--- a/rules.ini
+++ b/rules.ini
@@ -59,6 +59,7 @@ Unreal[] = (?:^|/)Engine/Binaries/ThirdParty/
 Unreal[] = (?:^|/)Binaries/Win(?:32|64)/
 Unreal[] = (?:^|/)UnrealEd\.
 Wintermute = (?:^|/)(?:wme_steam\.dll|data\.dcp)$
+Defold = (?:^|/)game\.arc(?:d|i)$
 Godot = (?:^|/)(?:GODOT|libqodot\.dll$)
 GoldSource = ^hltv\.exe$
 Source = (?:^|/)(?:vphysics|bsppack)\.(?:dylib|dll|so)$


### PR DESCRIPTION
Defold's archive data and index files; named "game.arcd" and "game.arci" respectively; are consistent across all supported platforms (e.g. Android, iOS, Linux, macOS, Windows)