### PR TITLE
Add nProtect GameGuard

### DIFF
--- a/descriptions/AntiCheat.nProtect_GameGuard.md
+++ b/descriptions/AntiCheat.nProtect_GameGuard.md
@@ -1,0 +1,1 @@
+[**nProtect GameGuard**](https://gameguard.nprotect.com/) (sometimes called *GG*) is an anti-cheat technology developed by INCA Internet. It utilises rootkit-like behaviour in order to protect game clients, such as blocking certain system API calls and keylogging.

--- a/rules.ini
+++ b/rules.ini
@@ -102,6 +102,7 @@ SCUMMVM = (?:^|/)scummvm\.exe$
 BattlEye = (?:^|/)BEService(?:_x64)?\.exe$
 EasyAntiCheat = (?:^|/)EasyAntiCheat/.*
 PunkBuster = (?:^|/)(?:PnkBstrA|pbsvc)\.exe$
+nProtect_GameGuard = (?:^|/)gameguard\.des$
 
 [SDK]
 AMD_GPU_Services = (?:^|/)amd_ags_x(?:64|86).dll$

--- a/tests/types/AntiCheat.nProtect_GameGuard.txt
+++ b/tests/types/AntiCheat.nProtect_GameGuard.txt
@@ -1,0 +1,3 @@
+/GameGuard.des
+GameGuard.des
+pso2_bin/GameGuard.des

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -361,3 +361,5 @@ steamnet.dll
 bin/x64/steamnetworkingsockets.sooooo
 amd_ags_x42.dll
 Binaries/amd_ags_x64.dlll
+GameGuard.desu
+pso2_bin/GameGuarded.des


### PR DESCRIPTION
### SteamDB app page links to a few games using this

[Phantasy Star Online 2](https://steamdb.info/app/1056640/)
[CABAL Online](https://steamdb.info/app/253490/)

### Brief explanation of the change

Added the anti-cheat [nProtect GameGuard](https://en.wikipedia.org/wiki/nProtect_GameGuard) ([official site](https://gameguard.nprotect.com/)). May also match to `npptnt2.sys` per [this](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2005-0295) CVE, however not sure if there are any games on Steam that use this filename.

Thanks,
Elliott