### PR TITLE
Add a new SDK Qt

### DIFF
--- a/descriptions/SDK.Qt.md
+++ b/descriptions/SDK.Qt.md
@@ -1,0 +1,2 @@
+[**Qt**](https://www.qt.io/) is a toolkit for creating graphical user interfaces.
+Mainly used by the Source 2 engine among game engines.

--- a/descriptions/SDK.Qt.md
+++ b/descriptions/SDK.Qt.md
@@ -1,2 +1,1 @@
 [**Qt**](https://www.qt.io/) is a toolkit for creating graphical user interfaces.
-Mainly used by the Source 2 engine among game engines.

--- a/rules.ini
+++ b/rules.ini
@@ -114,4 +114,4 @@ Steam_Audio = (?:^|/)(?:lib)?steamaudio\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 NodeJS = (?:^|/)node\.dll$
-Qt = (?:^|/)Qt(?:Core4|5Core)\.dll$
+Qt = (?:^|/)Qt(?:Core4|\dCore)\.dll$

--- a/rules.ini
+++ b/rules.ini
@@ -114,4 +114,4 @@ Steam_Audio = (?:^|/)(?:lib)?steamaudio\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 NodeJS = (?:^|/)node\.dll$
-Qt = (?:^|/)Qt\w+\.dll$
+Qt = (?:^|/)Qt(?:\d|)Core(?:\d|)\.dll$

--- a/rules.ini
+++ b/rules.ini
@@ -114,4 +114,4 @@ Steam_Audio = (?:^|/)(?:lib)?steamaudio\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 NodeJS = (?:^|/)node\.dll$
-Qt = (?:^|/)Qt(?:\d|)Core(?:\d|)\.dll$
+Qt = (?:^|/)Qt(?:Core4|5Core)\.dll$

--- a/rules.ini
+++ b/rules.ini
@@ -114,3 +114,4 @@ Steam_Audio = (?:^|/)(?:lib)?steamaudio\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 NodeJS = (?:^|/)node\.dll$
+Qt = (?:^|/)Qt\w+\.dll$

--- a/tests/types/SDK.Qt.txt
+++ b/tests/types/SDK.Qt.txt
@@ -1,0 +1,4 @@
+Engine/Binaries/ThirdParty/Simul/Win64/Qt5Core.dll
+Qt5Core.dll
+game/bin/win64/Qt5Core.dll
+game/bin/win64/QtCore4.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -368,4 +368,3 @@ tobbii_gameintegration_x64.dll
 Plugins/ToobiiEyetracking/ThirdParty/GameIntegration/lib/Win64/Toobii.GameIntegration.dll
 game/bin/win64/qt_plugins/sqldrivers/qsqlited4.dll
 game/bin/win64/qt_plugins/qmltooling/qmldbg_tcpd4.dll
-Engine/Binaries/ThirdParty/Simul/Win64/SequencerQtWidgets_MD.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -366,3 +366,6 @@ pso2_bin/GameGuarded.des
 Toobbii.EyeX.Client.dlll
 tobbii_gameintegration_x64.dll
 Plugins/ToobiiEyetracking/ThirdParty/GameIntegration/lib/Win64/Toobii.GameIntegration.dll
+game/bin/win64/qt_plugins/sqldrivers/qsqlited4.dll
+game/bin/win64/qt_plugins/qmltooling/qmldbg_tcpd4.dll
+Engine/Binaries/ThirdParty/Simul/Win64/SequencerQtWidgets_MD.dll


### PR DESCRIPTION
Games using this SDK:
 - [Half-Life: Alyx](https://steamdb.info/app/546560)
 - [s&box](https://steamdb.info/app/590830)
 - [Dota 2](https://steamdb.info/app/570)
 - [Cyberpunk 2077](https://steamdb.info/app/1091500)
 - [ARK: Survival Evolved](https://steamdb.info/app/346110)

The main target file is basically `Qt5Core.dll`, Alyx uses Qt4 rather than Qt5 and its core file name is `QtCore4.dll`.
