### PR TITLE
Detect projects with Godot source code (`project.godot`)

### DIFF
--- a/rules.ini
+++ b/rules.ini
@@ -53,6 +53,7 @@ CryEngine[] = (?:^|/)engine\.pak$
 CryEngine[] = \.cry$
 Defold = (?:^|/)game\.dmanifest$
 FNA = (?:^|/)fna\.dll$
+Godot = (?:^|/)project\.godot$
 GoldSource = ^hltv\.exe$
 HaemimontSol = ^Local/English\.hpk$
 idTech2 = (?:^|/)baseq2(?:$|/)

--- a/tests/types/Engine.Godot.txt
+++ b/tests/types/Engine.Godot.txt
@@ -1,0 +1,3 @@
+/project.godot
+Sub/Folder/project.godot
+project.godot

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -405,3 +405,5 @@ GFSDK_Aftermath_Lib_UWP.x86
 GFSDK_Aftermath_Lib_UWP.x64
 gfsdk_aftermath_lib
 sdfdata
+thisaintproject.godot
+project.godotfork


### PR DESCRIPTION
### SteamDB app page links to a few games using this

https://steamdb.info/app/404790/

### Brief explanation of the change

`project.godot` is a file which should be included with any source code distribution
for Godot engine.

Most games do not ship with source code of course, but some might, and the
Godot Engine app itself ships with demos source code, which should be matched
by this rule.

**PLEASE TEST.** I did not test it myself. It should match at least [Godot Engine](https://steamdb.info/app/404790/), and might match a few other entries if they ship Godot source code.

I found one Godot game which is currently not matched because it's shipped as a full source code release only: https://steamdb.info/app/808580

But it's a Godot 2.1 game and there the engine entry point was named `engine.cfg`, which is IMO too common a name to use as evidence for Godot, even if it's a strong hint. It might also be the only pre-Godot 3.0 game that does this so we can live with that false negative.

Other options to match source code would be things like `default_env.tres`, `*.gd`, `*.tscn`, but I'm wary of potential false positives.