### PR TITLE
Add Virtools engine

### DIFF
--- a/descriptions/Engine.Virtools.md
+++ b/descriptions/Engine.Virtools.md
@@ -1,0 +1,1 @@
+[**Virtools**](http://www.virtools.com/) is a 3D rendering engine developed by Virtools SA.

--- a/rules.ini
+++ b/rules.ini
@@ -99,6 +99,7 @@ Unreal[] = (?:^|/)Engine/Binaries/ThirdParty/
 Unreal[] = (?:^|/)UnrealEd\.
 UPBGE[] = (?:^|/)BlendThumb(?:64|)\.dll$
 UPBGE[] = (?:^|/)blenderplayer\.exe$
+Virtools = (?:^|/)CKDX[7-9]Rasterizer\.dll$
 VisionaireStudio = (?:^|/)VisionaireConfigurationTool\.exe(?:$|/)
 Wintermute = (?:^|/)(?:wme_steam\.dll|data\.dcp)$
 WolfRPGEditor = data\.wolf$

--- a/tests/types/Engine.Virtools.txt
+++ b/tests/types/Engine.Virtools.txt
@@ -1,0 +1,4 @@
+CKDX8Rasterizer.dll
+Dlls/ckdx7rasterizer.dll
+sub/dir/CKDX8Rasterizer.dll
+RenderEngines/CKDX9Rasterizer.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -513,6 +513,9 @@ angle/libEGLMarmalade_dll
 angle/libGLESv2Marmalade_dll
 angle/libEGL_Marmalade.dll
 angle/libGLESv2_Marmalade.dll
+CKDX6Rasterizer.dll
+CKDX10Rasterizer.dll
+CKDX7Rasterizer_dll
 libopenvr_api
 openvr_api
 libopenvr_api_so


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this

https://steamdb.info/app/46500/
https://steamdb.info/app/46510/
https://steamdb.info/app/832540/
https://steamdb.info/app/46550/
https://steamdb.info/app/46480/
https://steamdb.info/app/34800/

### Brief explanation of the change

Add Virtools engine. It's used in Syberia, Syberia 2, and some other old games.
Its distinctive files - CK2.dll, CK2_3D.dll, VirtoolsLoader.dll(or VirtoolsLoaderR.dll), and either one of CKDX7Rasterizer.dll, CKDX8Rasterizer.dll, CKDX9Rasterizer.dll. The rule is set to detect one of the latter ones.