### PR TITLE
add HashLink engine

### DIFF
--- a/descriptions/Engine.HashLink.md
+++ b/descriptions/Engine.HashLink.md
@@ -1,0 +1,1 @@
+[**HashLink**](https://hashlink.haxe.org/) is a virtual machine for Haxe.

--- a/rules.ini
+++ b/rules.ini
@@ -61,6 +61,7 @@ GameMaker[] = \.gm(?:spr|bck)$
 Godot = (?:^|/)project\.godot$ ; Extra detections are in IsEngineGodot
 GoldSource = ^hltv\.exe$
 HaemimontSol = ^Local/English\.hpk$
+HashLink = (?:^|/)libhl\.(?:dll|so)$
 idTech2 = (?:^|/)gl(?:quake|hexen)(?:$|/)
 idTech2_5 = (?:^|/)baseq2(?:$|/)
 idTech4 = \.pk4$

--- a/tests/types/Engine.HashLink.txt
+++ b/tests/types/Engine.HashLink.txt
@@ -1,0 +1,6 @@
+/libhl.dll
+Sub/Folder/libhl.dll
+libhl.dll
+/libhl.so
+Sub/Folder/libhl.so
+libhl.so

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -39,6 +39,10 @@ dEngine.BuildInfo_Win32_retail.dll
 dEngine.BuildInfo_Win32_retail_dll.dll
 dEngine.BuildInfo_Win64_retail.dll
 dEngine.BuildInfo_Win64_retail_dll.dll
+libhl.dlll
+libhl.soo
+libhl_so
+libhl_dll
 Engine.BuildInfo.dlld
 Engine.BuildInfo_Win32_retail.dlld
 Engine.BuildInfo_Win32_retail_dll.dlld


### PR DESCRIPTION
### SteamDB app page links to a few games using this

https://steamdb.info/app/588650/
https://steamdb.info/app/466560/
https://steamdb.info/app/939100/
https://steamdb.info/app/1527950/
https://steamdb.info/app/1020470/

### Brief explanation of the change

Add HashLink engine. This is a bytecode virtual machine based on Haxe. Used by the above games (Dead Cells, Northgard, more).
