### PR TITLE
Add Kex engine

### DIFF
--- a/descriptions/Engine.Kex.md
+++ b/descriptions/Engine.Kex.md
@@ -1,0 +1,1 @@
+[**Kex Engine**](https://www.nightdivestudios.com/kex/) is a proprietary cross-platform game engine framework originally created by  Samuel "Kaiser" Villarreal for Nightdive Studios.

--- a/rules.ini
+++ b/rules.ini
@@ -70,6 +70,7 @@ idTech5 = \.streamed$
 idTech6[] = \.mega2$
 idTech6[] = \.texdb$
 idTech7 = \.streamdb$
+Kex = \.kpf$
 KiriKiri = (?:^|/)KAGParserEx\.dll$
 Lime_OR_OpenFL = (?:^|/)lime(?:-legacy)?\.[hn]dll$
 Love2D = (?:^|/)(?:lib)?love\.(?:dll|so|so\.0)$

--- a/tests/types/Engine.Kex.txt
+++ b/tests/types/Engine.Kex.txt
@@ -1,0 +1,5 @@
+rerelease/QuakeEX.kpf
+BloodEX.kpf
+sshock.kpf
+Doom64.kpf
+sub/dir/game.kpf

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -534,6 +534,9 @@ OgreMain_dll
 OgreMain_x64_dll
 OgreMain_dlll
 VOgreMain.dll
+somefile.kpfwhoops
+somefilekpf
+somefile_kpf
 bink2w64.ddl
 notabink.dll
 binkw23.dll


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this

https://steamdb.info/app/1148590/
https://steamdb.info/app/1010750/
https://steamdb.info/app/2310/
https://steamdb.info/app/410710/
https://steamdb.info/app/405820/
https://steamdb.info/app/668980/

### Brief explanation of the change

Add Kex engine. It is used by Nightdive Studios to remaster old titles like Doom 64, Blood, Turok, System Shock, recently released Quake 2021 rerelease, etc.
