### PR TITLE
Adding Unity's Universal Render Pipeline as SDK

### DIFF
--- a/descriptions/SDK.UnityURP.md
+++ b/descriptions/SDK.UnityURP.md
@@ -1,0 +1,1 @@
+[**URP**](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@11.0/manual/index.html) The Universal Render Pipeline is a prebuilt Scriptable Render Pipeline, made by Unity. URP provides artist-friendly workflows that let you quickly and easily create optimized graphics across a range of platforms, from mobile to high-end consoles and PCs.

--- a/descriptions/SDK.UnityURP.md
+++ b/descriptions/SDK.UnityURP.md
@@ -1,1 +1,1 @@
-[**URP**](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@11.0/manual/index.html) URP is a customizable cross-platform Scriptable Render Pipeline built by Unity to target all modern platforms.
+[**URP**](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@11.0/manual/index.html) is a customizable cross-platform Scriptable Render Pipeline built by Unity to target all modern platforms.

--- a/descriptions/SDK.UnityURP.md
+++ b/descriptions/SDK.UnityURP.md
@@ -1,1 +1,1 @@
-[**URP**](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@11.0/manual/index.html) The Universal Render Pipeline is a prebuilt Scriptable Render Pipeline, made by Unity. URP provides artist-friendly workflows that let you quickly and easily create optimized graphics across a range of platforms, from mobile to high-end consoles and PCs.
+[**URP**](https://docs.unity3d.com/Packages/com.unity.render-pipelines.universal@11.0/manual/index.html) URP is a customizable cross-platform Scriptable Render Pipeline built by Unity to target all modern platforms.

--- a/rules.ini
+++ b/rules.ini
@@ -150,5 +150,6 @@ Tobii = (?:^|/)Tobii
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$
 UnityURP[] = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:Shaders|Runtime)\.dll$
 UnityURP[] = (?:^|/)Unity\.RenderPipeline\.Universal\.(?:ShaderLibrary)\.dll$
+UnityURP[] = (?:^|/)Aragami2_Data/il2cpp_data/etc/mono$
 
 Wwise = (?:^|/)AkSoundEngine(?:dll)?\.(?:bundle|dll)$

--- a/rules.ini
+++ b/rules.ini
@@ -148,6 +148,5 @@ Steam_Audio = (?:^|/)(?:lib)?(?:steamaudio|phonon)\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$
-UnityURP[] = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:Shaders|Runtime)\.dll$
-UnityURP[] = (?:^|/)Unity\.RenderPipeline\.Universal\.ShaderLibrary\.dll$
+UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.Runtime\.dll$
 Wwise = (?:^|/)AkSoundEngine(?:dll)?\.(?:bundle|dll)$

--- a/rules.ini
+++ b/rules.ini
@@ -148,5 +148,7 @@ Steam_Audio = (?:^|/)(?:lib)?(?:steamaudio|phonon)\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$
-UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:ShaderLibrary|Shaders|Runtime)\.dll$
+UnityURP[] = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:Shaders|Runtime)\.dll$
+UnityURP[] = (?:^|/)Unity\.RenderPipeline\.Universal\.(?:ShaderLibrary)\.dll$
+
 Wwise = (?:^|/)AkSoundEngine(?:dll)?\.(?:bundle|dll)$

--- a/rules.ini
+++ b/rules.ini
@@ -148,4 +148,5 @@ Steam_Audio = (?:^|/)(?:lib)?(?:steamaudio|phonon)\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$
+UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:Config\.Runtime|Shaders|Runtime)\.dll$
 Wwise = (?:^|/)AkSoundEngine(?:dll)?\.(?:bundle|dll)$

--- a/rules.ini
+++ b/rules.ini
@@ -148,5 +148,6 @@ Steam_Audio = (?:^|/)(?:lib)?(?:steamaudio|phonon)\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$
-UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:Shaders|Runtime)\.dll$
+UnityURP[] = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:Shaders|Runtime)\.dll$
+UnityURP[] = (?:^|/)Unity\.RenderPipeline\.Universal\.ShaderLibrary\.dll$
 Wwise = (?:^|/)AkSoundEngine(?:dll)?\.(?:bundle|dll)$

--- a/rules.ini
+++ b/rules.ini
@@ -148,5 +148,5 @@ Steam_Audio = (?:^|/)(?:lib)?(?:steamaudio|phonon)\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$
-UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:ShaderLibrary\.Runtime|Shaders|Runtime)\.dll$
+UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:ShaderLibrary|Shaders|Runtime)\.dll$
 Wwise = (?:^|/)AkSoundEngine(?:dll)?\.(?:bundle|dll)$

--- a/rules.ini
+++ b/rules.ini
@@ -148,5 +148,5 @@ Steam_Audio = (?:^|/)(?:lib)?(?:steamaudio|phonon)\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$
-UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:Config\.Runtime|Shaders|Runtime)\.dll$
+UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:ShaderLibrary\.Runtime|Shaders|Runtime)\.dll$
 Wwise = (?:^|/)AkSoundEngine(?:dll)?\.(?:bundle|dll)$

--- a/rules.ini
+++ b/rules.ini
@@ -148,8 +148,5 @@ Steam_Audio = (?:^|/)(?:lib)?(?:steamaudio|phonon)\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$
-UnityURP[] = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:Shaders|Runtime)\.dll$
-UnityURP[] = (?:^|/)Unity\.RenderPipeline\.Universal\.(?:ShaderLibrary)\.dll$
-UnityURP[] = (?:^|/)Aragami2_Data/il2cpp_data/etc/mono$
-
+UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.(?:Shaders|Runtime)\.dll$
 Wwise = (?:^|/)AkSoundEngine(?:dll)?\.(?:bundle|dll)$

--- a/tests/types/SDK.UnityURP.txt
+++ b/tests/types/SDK.UnityURP.txt
@@ -1,7 +1,4 @@
 /Unity.RenderPipelines.Universal.Runtime.dll
-/Unity.RenderPipelines.Universal.Shaders.dll
-/Unity.RenderPipeline.Universal.ShaderLibrary.dll
 
 Unity.RenderPipelines.Universal.Runtime.dll
-Unity.RenderPipelines.Universal.Shaders.dll
-Unity.RenderPipeline.Universal.ShaderLibrary.dll
+

--- a/tests/types/SDK.UnityURP.txt
+++ b/tests/types/SDK.UnityURP.txt
@@ -1,5 +1,7 @@
 /Unity.RenderPipelines.Universal.Runtime.dll
 /Unity.RenderPipelines.Universal.Shaders.dll
+/Unity.RenderPipeline.Universal.ShaderLibrary.dll
 
 Unity.RenderPipelines.Universal.Runtime.dll
 Unity.RenderPipelines.Universal.Shaders.dll
+Unity.RenderPipeline.Universal.ShaderLibrary.dll

--- a/tests/types/SDK.UnityURP.txt
+++ b/tests/types/SDK.UnityURP.txt
@@ -1,0 +1,9 @@
+/Unity.RenderPipeline.Universal.ShaderLibrary.dll
+/Unity.RenderPipelines.Universal.Runtime.dll
+/Unity.RenderPipelines.Universal.Shaders.dll
+/Aragami2_Data/il2cpp_data/etc/mono
+
+Unity.RenderPipeline.Universal.ShaderLibrary.dll
+Unity.RenderPipelines.Universal.Runtime.dll
+Unity.RenderPipelines.Universal.Shaders.dll
+Aragami2_Data/il2cpp_data/etc/mono

--- a/tests/types/SDK.UnityURP.txt
+++ b/tests/types/SDK.UnityURP.txt
@@ -1,9 +1,5 @@
-/Unity.RenderPipeline.Universal.ShaderLibrary.dll
 /Unity.RenderPipelines.Universal.Runtime.dll
 /Unity.RenderPipelines.Universal.Shaders.dll
-/Aragami2_Data/il2cpp_data/etc/mono
 
-Unity.RenderPipeline.Universal.ShaderLibrary.dll
 Unity.RenderPipelines.Universal.Runtime.dll
 Unity.RenderPipelines.Universal.Shaders.dll
-Aragami2_Data/il2cpp_data/etc/mono


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this
https://steamdb.info/app/1307550
https://steamdb.info/app/1062090
https://steamdb.info/app/1158370/


### Brief explanation of the change
Adds unity's Universal Render Pipeline, which is a Scriptable render pipeline. Unity has two, HDRP and URP, and they're the new and supported 'graphic' backends of unity. The old one is on long-term bug fixing only.
View #96 for more info.

