### PR TITLE
Add detection vectors for EQU8 Anti-Cheat

### DIFF
--- a/descriptions/AntiCheat.EQU8.md
+++ b/descriptions/AntiCheat.EQU8.md
@@ -1,0 +1,1 @@
+[**EQU8**](https://www.equ8.com/) is a lightweight client-side anti-cheat solution created by Int3 Software. It is designed to protect games from hackers and cheaters as well as analyzing statistics for developers.

--- a/rules.ini
+++ b/rules.ini
@@ -121,10 +121,9 @@ SCUMMVM = (?:^|/)scummvm\.exe$
 [AntiCheat]
 BattlEye = (?:^|/)BEService(?:_x64)?\.exe$
 EasyAntiCheat = (?:^|/)EasyAntiCheat/.*
+EQU8 = (?:^|/)equ8_conf\.json$
 nProtect_GameGuard = (?:^|/)gameguard\.des$
 PunkBuster = (?:^|/)(?:PnkBstrA|pbsvc)\.exe$
-EQU8[] = (?:^|/)equ8_conf\.json$
-EQU8[] = (?:^|/)equ8\.db$
 
 [SDK]
 Adobe_Flash[] = (?:^|/)Flash[ _]?Player(?:$|/|\.)

--- a/rules.ini
+++ b/rules.ini
@@ -123,6 +123,8 @@ BattlEye = (?:^|/)BEService(?:_x64)?\.exe$
 EasyAntiCheat = (?:^|/)EasyAntiCheat/.*
 nProtect_GameGuard = (?:^|/)gameguard\.des$
 PunkBuster = (?:^|/)(?:PnkBstrA|pbsvc)\.exe$
+EQU8[] = (?:^|/)equ8_conf\.json$
+EQU8[] = (?:^|/)equ8\.db$
 
 [SDK]
 Adobe_Flash[] = (?:^|/)Flash[ _]?Player(?:$|/|\.)

--- a/tests/types/AntiCheat.EQU8.txt
+++ b/tests/types/AntiCheat.EQU8.txt
@@ -1,0 +1,3 @@
+equ8_conf.json
+Sub/Plugins/equ8.db
+Sub/Plugins/EQU8/ThirdParty/equ8_client/equ8.db

--- a/tests/types/AntiCheat.EQU8.txt
+++ b/tests/types/AntiCheat.EQU8.txt
@@ -1,3 +1,1 @@
 equ8_conf.json
-Sub/Plugins/equ8.db
-Sub/Plugins/EQU8/ThirdParty/equ8_client/equ8.db

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -413,6 +413,9 @@ PhysX_32.dlll
 Dll/x64/PhisX_64.dll
 PysXCore.dll
 PhysXLoder.dll
+equ8_db
+totallynotequ8_conf.json
+sub/dir/equ8.dblol
 c2runtimexjs
 c3runtimexjs
 ac2runtime.js

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -415,7 +415,7 @@ PysXCore.dll
 PhysXLoder.dll
 equ8_db
 totallynotequ8_conf.json
-sub/dir/equ8.dblol
+sub/dir/equ8.jsondblol
 c2runtimexjs
 c3runtimexjs
 ac2runtime.js


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this
https://steamdb.info/app/824270/
https://steamdb.info/app/677620/
https://steamdb.info/app/823130/


### Brief explanation of the change
Adds detection support for EQU8 Anti-Cheat under AntiCheat section by finding `equ8_conf.json` which is required for EQU8 Anti-Cheat.

(There are additional detection vectors available as well but these are the main ones that are mentioned in the [documentation for anticheat distribution](https://equ8.gitbook.io/documentation/integration-guide/distributing-with-equ8)


