### PR TITLE
Add detection for games using JVM (Java Virtual Machine)

### DIFF
--- a/descriptions/SDK.JVM.md
+++ b/descriptions/SDK.JVM.md
@@ -1,0 +1,1 @@
+[**Java Virtual Machine**](https://en.wikipedia.org/wiki/Java_virtual_machine) is a runtime environment for executing applications written in Java and other JVM-based languages.

--- a/rules.ini
+++ b/rules.ini
@@ -139,6 +139,7 @@ CRIWARE = \.(?:cpk|sfd|usm|adx|acb|awb)$
 Discord = (?:^|/)(?:lib)?discord(?:|-rpc|_game_sdk)\.(?:dll|dylib|so)$
 EpicOnlineServices = (?:^|/)(?:lib)?eossdk
 FMOD = (?:^|/)(?:lib)?fmod(?:l|ex|exl|studio|studiol|)(?:64)?\.(?:dylib|dll|so)$
+JVM = (?:^|/)bin/java(?:\.exe|\.dll)?$
 NodeJS = (?:^|/)node\.dll$
 NVIDIA_Ansel = (?:^|/)AnselSDK(?:32|64)\.dll$
 NVIDIA_DLSS = (?:^|/)nvngx_dlss\.dll$

--- a/tests/types/SDK.JVM.txt
+++ b/tests/types/SDK.JVM.txt
@@ -1,0 +1,6 @@
+jre/bin/java.exe
+jre/bin/java.dll
+jre/bin/java
+bin/java.dll
+long/random/path/bin/java
+wildermyth.app/Contents/Resources/jre/bin/java

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -556,5 +556,8 @@ defines.txt
 00_defines.txt
 /AkEngine.dll
 AkSoundEnginedlll.dll
+/coffee/java.png
+jre/java.json
+random/jre/stuff.exe
 OpenAL42.dll
 /OpenAL.dll


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this

https://steamdb.info/app/1127400/
https://steamdb.info/app/646570/
https://steamdb.info/app/546430/
https://steamdb.info/app/979110/


### Brief explanation of the change

I initially tried to build a rule set for [libGDX](https://libgdx.com/), but doing that by file names alone seems to be impossible (because the libGDX bits are inside .jar files). However, most games using libGDX at least includes a bundled JVM, and in a easy to recognize way.

