### PR TITLE
add Solarus engine detection

### DIFF
--- a/descriptions/Engine.Solarus.md
+++ b/descriptions/Engine.Solarus.md
@@ -1,0 +1,1 @@
+[**Solarus**](https://solarus-games.org/) is a lightweight, free and open-source game engine for Action-RPGs

--- a/rules.ini
+++ b/rules.ini
@@ -95,6 +95,7 @@ RPGMaker[] = (?:^|/)RPG_RT\.ini$
 RPGMaker[] = \.(?:rgssad|rvproj2|rgss3a|rgss2a)$
 Snowdrop = \.sdfdata$
 Solar2D = (?:^|/)CoronaLabs\.Corona\.Native\.dll$
+Solarus = \.solarus$
 Source = (?:^|/)(?:vphysics|bsppack)\.(?:dylib|dll|so)$
 Source2 = (?:^|/)gameinfo\.gi$
 TelltaleTool = \.ttarch$

--- a/tests/types/Engine.Solarus.txt
+++ b/tests/types/Engine.Solarus.txt
@@ -1,0 +1,4 @@
+.solarus
+data.solarus
+Sub/Folder/0_9.solarus
+test-1.2.3d.solarus

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -418,6 +418,9 @@ PhysXLoder.dll
 equ8_db
 totallynotequ8_conf.json
 sub/dir/equ8.jsondblol
+name_solarus
+thing.solarus.txt
+data.solaruss
 c2runtimexjs
 c3runtimexjs
 ac2runtime.js


### PR DESCRIPTION
### SteamDB app page links to a few games using this

https://steamdb.info/app/1393750/

There might be more commercial games that use it that I don't know of.

### Brief explanation of the change

Solarus is an open-source Action-RPG game engine to make games in the style of the SNES Zelda games.
