### PR TITLE
Add EAC Proton rules

### DIFF
--- a/descriptions/AntiCheat.EasyAntiCheatProton.md
+++ b/descriptions/AntiCheat.EasyAntiCheatProton.md
@@ -1,0 +1,1 @@
+[**Easy Anti-Cheat Proton**](https://www.easy.ac/) is the industry-leading anti–cheat service, countering hacking and cheating in multiplayer PC games through the use of hybrid anti–cheat mechanisms with Proton support. 

--- a/rules.ini
+++ b/rules.ini
@@ -126,6 +126,7 @@ SCUMMVM = (?:^|/)scummvm\.exe$
 [AntiCheat]
 BattlEye = (?:^|/)BEService(?:_x64)?\.exe$
 EasyAntiCheat = (?:^|/)EasyAntiCheat/.*
+EasyAntiCheatProton = /easyanticheat_x(?:64|86)\.so$
 EQU8 = (?:^|/)equ8_conf\.json$
 nProtect_GameGuard = (?:^|/)gameguard\.des$
 PunkBuster = (?:^|/)(?:PnkBstrA|pbsvc)\.exe$

--- a/tests/types/AntiCheat.EasyAntiCheatProton.txt
+++ b/tests/types/AntiCheat.EasyAntiCheatProton.txt
@@ -1,0 +1,4 @@
+EasyAntiCheat/easyanticheat_x64.so
+EasyAntiCheat/easyanticheat_x86.so
+Sub/Folder/EasyAntiCheat/easyanticheat_x64.so
+Sub/Folder/EasyAntiCheat/easyanticheat_x86.so

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -19,6 +19,9 @@ ChEasyAntiCheat/
 EasyAntiCheat.whatever
 SomeEngine/Binaries/ThirdParty
 Engine/Binaries/ThirdPartySomething
+Someeasyanticheat_x64.so
+easyanticheat_x64.soextra
+easyanticheat_x64.nso
 blahrpg_rt.exe
 sub/blahrpg_rt.exe
 rgssad


### PR DESCRIPTION
### SteamDB app page links to a few games using this
https://steamdb.info/depot/386361/
https://steamdb.info/depot/1158941/


### Brief explanation of the change
Added the posibility to find EAC games that have enabled proton according to the Steam Deck Anti-Cheat update https://store.steampowered.com/news/group/4145017?emclan=103582791433666425&emgid=3137321254689909033

