### PR TITLE
Godot: Add support for .x86_32 extension for Linux x86 32-bit

### DIFF
--- a/tests/FileDetector.php
+++ b/tests/FileDetector.php
@@ -285,11 +285,15 @@ class FileDetector
 			{
 				$Exes[ $swapExtension( $BaseFile, ".exe", ".pck" ) ] = true;
 			}
-			else if( $Extension === 'x86' )
+			else if( $Extension === 'x86' ) // 32-bit Linux in Godot 2.x/3.x
 			{
 				$Exes[ $swapExtension( $BaseFile, ".x86", ".pck" ) ] = true;
 			}
-			else if( $Extension === 'x86_64' )
+			else if( $Extension === 'x86_32' ) // 32-bit Linux in Godot 4.x
+			{
+				$Exes[ $swapExtension( $BaseFile, ".x86_32", ".pck" ) ] = true;
+			}
+			else if( $Extension === 'x86_64' ) // 64-bit Linux in all versions
 			{
 				$Exes[ $swapExtension( $BaseFile, ".x86_64", ".pck" ) ] = true;
 			}

--- a/tests/filelists/Engine.Godot.TestLinux32.txt
+++ b/tests/filelists/Engine.Godot.TestLinux32.txt
@@ -1,0 +1,2 @@
+MyGame.x86_32
+MyGame.pck

--- a/tests/filelists/Engine.Godot.TestLinux32Old.txt
+++ b/tests/filelists/Engine.Godot.TestLinux32Old.txt
@@ -1,0 +1,2 @@
+MyGame.x86
+MyGame.pck

--- a/tests/filelists/Engine.Godot.TestLinux64.txt
+++ b/tests/filelists/Engine.Godot.TestLinux64.txt
@@ -1,0 +1,2 @@
+MyGame.x86_64
+MyGame.pck

--- a/tests/filelists/Engine.Godot.TestMacOS.txt
+++ b/tests/filelists/Engine.Godot.TestMacOS.txt
@@ -1,0 +1,9 @@
+MyGame.app
+MyGame.app/Contents
+MyGame.app/Contents/Info.plist
+MyGame.app/Contents/MacOS
+MyGame.app/Contents/MacOS/MyGame
+MyGame.app/Contents/PkgInfo
+MyGame.app/Contents/Resources
+MyGame.app/Contents/Resources/icon.icns
+MyGame.app/Contents/Resources/MyGame.pck

--- a/tests/filelists/Engine.Godot.TestWindows.txt
+++ b/tests/filelists/Engine.Godot.TestWindows.txt
@@ -1,0 +1,2 @@
+MyGame.exe
+MyGame.pck


### PR DESCRIPTION
### SteamDB app page links to a few games using this

None yet, it's future proofing for Godot 4.0.

### Brief explanation of the change

The extension changed from .x86 to .x86_32 in Godot 4.0.

Ref. https://github.com/godotengine/godot/pull/59394
