### PR TITLE
Add detection for Godot's new 32-bit x86 suffix of `x86_32`

### DIFF
--- a/tests/FileDetector.php
+++ b/tests/FileDetector.php
@@ -289,6 +289,10 @@ class FileDetector
 			{
 				$Exes[ $swapExtension( $BaseFile, ".x86", ".pck" ) ] = true;
 			}
+			else if( $Extension === 'x86_32' )
+			{
+				$Exes[ $swapExtension( $BaseFile, ".x86_32", ".pck" ) ] = true;
+			}
 			else if( $Extension === 'x86_64' )
 			{
 				$Exes[ $swapExtension( $BaseFile, ".x86_64", ".pck" ) ] = true;


### PR DESCRIPTION
### SteamDB app page links to a few games using this

None yet, this is for Godot 4.0, which hasn't been released yet.

### Brief explanation of the change

This PR adds detection for this change in Godot: https://github.com/godotengine/godot/pull/59394

In the future, there will likely also be support for `arm64`, `arm32`, `rv64`, etc, we can add those here once Godot does.