### PR TITLE
[Minor, meta] Fix SDK template to actually add the SDK label

### DIFF
--- a/.github/ISSUE_TEMPLATE/6_type_sdk.yml
+++ b/.github/ISSUE_TEMPLATE/6_type_sdk.yml
@@ -1,6 +1,6 @@
 name: Suggest an SDK detection
 description: Suggest an SDK (software development kit) that is not being currently detected.
-labels: ["Type: Engine"]
+labels: ["Type: SDK"]
 body:
 - type: textarea
   attributes:


### PR DESCRIPTION
Noticed this in https://github.com/SteamDatabase/FileDetectionRuleSets/issues/131