### PR TITLE
Change Torque engine URL

### DIFF
--- a/descriptions/Engine.Torque.md
+++ b/descriptions/Engine.Torque.md
@@ -1,1 +1,1 @@
-[**Torque Game Engine**](http://www.garagegames.com/products/torque-3d) is an open-source cross-platform 3D game engine, developed by GarageGames and actively maintained under the current versions Torque 3D as well as Torque 2D.
+[**Torque Game Engine**](https://en.wikipedia.org/wiki/Torque_(game_engine)) is an open-source cross-platform 3D game engine, developed by GarageGames and actively maintained under the current versions Torque 3D as well as Torque 2D.


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### Brief explanation of the change

GarageGames.com has shut down and as such the original URL now points to a 404 page. This changes the URL to point to the Wikipedia article instead.