### PR TITLE
Add rules for AMD FSR2

### DIFF
--- a/descriptions/SDK.AMD_FSR2.md
+++ b/descriptions/SDK.AMD_FSR2.md
@@ -1,0 +1,1 @@
+[**AMD FidelityFX Super Resolution 2 (FSR2)**](https://github.com/GPUOpen-Effects/FidelityFX-FSR2/) is a cutting-edge upscaling technique developed from the ground up to produce high resolution frames from lower resolution inputs.

--- a/rules.ini
+++ b/rules.ini
@@ -138,7 +138,7 @@ XIGNCODE3 = \.xem$
 [SDK]
 Adobe_Flash[] = (?:^|/)Flash[ _]?Player(?:$|/|\.)
 Adobe_Flash[] = (?:^|/)StandalonePlayerLocalizable\.strings(?:$|/)
-AMD_FSR2 = (?:^|/)ffx_fsr2_api_(?:64|86)\.dll$
+AMD_FSR2 = (?:^|/)ffx_fsr2_api_x(?:64|86)\.dll$
 AMD_GPU_Services = (?:^|/)amd_ags_x(?:64|86)\.dll$
 Azure_Playfab_Party = (?:^|/)Party(?:Win|Win7|Win32|XboxLive|XboxLiveWin32)\.dll$
 Bink_Video = (?:^|/)bink2?w(?:64|32)?\.dll$

--- a/rules.ini
+++ b/rules.ini
@@ -139,6 +139,7 @@ XIGNCODE3 = \.xem$
 Adobe_Flash[] = (?:^|/)Flash[ _]?Player(?:$|/|\.)
 Adobe_Flash[] = (?:^|/)StandalonePlayerLocalizable\.strings(?:$|/)
 AMD_GPU_Services = (?:^|/)amd_ags_x(?:64|86)\.dll$
+AMD_FSR2 = (?:^|/)ffx_fsr2_api_(?:64|86)\.dll$
 Azure_Playfab_Party = (?:^|/)Party(?:Win|Win7|Win32|XboxLive|XboxLiveWin32)\.dll$
 Bink_Video = (?:^|/)bink2?w(?:64|32)?\.dll$
 CEF = (?:^|/)libcef\.(?:dll|so)$

--- a/rules.ini
+++ b/rules.ini
@@ -138,8 +138,8 @@ XIGNCODE3 = \.xem$
 [SDK]
 Adobe_Flash[] = (?:^|/)Flash[ _]?Player(?:$|/|\.)
 Adobe_Flash[] = (?:^|/)StandalonePlayerLocalizable\.strings(?:$|/)
-AMD_GPU_Services = (?:^|/)amd_ags_x(?:64|86)\.dll$
 AMD_FSR2 = (?:^|/)ffx_fsr2_api_(?:64|86)\.dll$
+AMD_GPU_Services = (?:^|/)amd_ags_x(?:64|86)\.dll$
 Azure_Playfab_Party = (?:^|/)Party(?:Win|Win7|Win32|XboxLive|XboxLiveWin32)\.dll$
 Bink_Video = (?:^|/)bink2?w(?:64|32)?\.dll$
 CEF = (?:^|/)libcef\.(?:dll|so)$

--- a/tests/types/SDK.AMD_FSR2.txt
+++ b/tests/types/SDK.AMD_FSR2.txt
@@ -1,0 +1,6 @@
+/ffx_fsr2_api_x64.dll
+/ffx_fsr2_api_x86.dll
+Binaries/ffx_fsr2_api_x64.dll
+ffx_fsr2_api_x64.dll
+ffx_fsr2_api_x86.dll
+win32/ffx_fsr2_api_x86.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -377,6 +377,8 @@ cry3denginexdll
 CryRenderD3D1xdll
 CryRenderD3D11xdll
 CryRenderD3D12xdll
+ffx_fsr2_api_x42.dll
+Binaries/ffx_fsr2_api_x64.dlll
 CryRenderVulkanxdll
 CryD3DCompilerStubxdll
 enginexpak
@@ -453,6 +455,10 @@ CoronaLabs_Corona_Native_dll
 Unigine_x64.pak
 UnigineEngine.dll
 Unigine_x86_dll
+/ffx_fsr2_api_x64@dll
+/ffx_fsr2_api_x86@dll
+ffx_fsr2_api_x64@dll
+ffx_fsr2_api_x86@dll
 libUnigine.so
 thisaintproject.godot
 project.godotfork


### PR DESCRIPTION
### SteamDB app page links to a few games using this

[Marvel’s Spider-Man Remastered](https://store.steampowered.com/app/1817070/Marvels_SpiderMan_Remastered/)

### Brief explanation of the change

Add rules for AMD FidelityFX Super Resolution 2 (FSR2).