### PR TITLE
Adds detection for games utilising the burst compiler.

### DIFF
--- a/descriptions/SDK.UnityBurst.md
+++ b/descriptions/SDK.UnityBurst.md
@@ -1,0 +1,1 @@
+[**Burst**](https://docs.unity3d.com/Packages/com.unity.burst@1.8/manual/index.html) The Burst package is a compiler designed to transform IL/.NET bytecode to optimized native CPU code, using LLVM.

--- a/rules.ini
+++ b/rules.ini
@@ -165,6 +165,7 @@ SteamworksNET = (?:^|/)(?:Steamworks\.NET\.dll|com\.rlabrecque\.steamworks\.net\
 Steam_Audio = (?:^|/)(?:lib)?(?:steamaudio|phonon)\.(?:dylib|dll|so)$
 Steam_Networking = (?:^|/)(?:lib)?steamnetworkingsockets\.(?:dylib|dll|so)$
 Tobii = (?:^|/)Tobii
+UnityBurst = (?:^|/)lib_burst_generated\.dll$
 UnityEntities[] = (?:^|/)Unity\.Entities\.dll$
 UnityEntities[] = (?:^|/)StreamingAssets/SubScenes/
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$

--- a/tests/types/SDK.UnityBurst.txt
+++ b/tests/types/SDK.UnityBurst.txt
@@ -1,0 +1,1 @@
+lib_burst_generated.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -43,6 +43,10 @@ libhl.dlll
 libhl.soo
 libhl_so
 libhl_dll
+lib_burst_generated_dll
+lib_burst_generatedd.dll
+lib_burst_generated.dlll
+llib_burst_generated.dlll
 Engine.BuildInfo.dlld
 Engine.BuildInfo_Win32_retail.dlld
 Engine.BuildInfo_Win32_retail_dll.dlld


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this
https://steamdb.info/app/1062090/
https://steamdb.info/app/1837750/

### Brief explanation of the change
Adds detection for the unity Burst sdk which is used to compile IL/.NET bytecode into native code.
