### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Something to emphasize is we are certainly undercounting engines/technology in t
 2. False negatives will keep us from detecting every instance of a particular technology, even if we have rules for it
 3. Some engines are fundamentally undetectable or extremely difficult to identify
 
-For instance, the [HaxeFlixel](haxeflixel.com/) game engine likely represents a large percentage of Lime/OpenFL games on Steam. However, HaxeFlixel does not leave a particular signature that easily distinguishes games made with it from conventional Lime/OpenFL games. We can't even distinguish between games made in Lime (a low level framework) and games made in OpenFL (a high level framework based on Lime). This pattern likely repeats with many other game engines and technologies.
+For instance, the [HaxeFlixel](https://haxeflixel.com/) game engine likely represents a large percentage of Lime/OpenFL games on Steam. However, HaxeFlixel does not leave a particular signature that easily distinguishes games made with it from conventional Lime/OpenFL games. We can't even distinguish between games made in Lime (a low level framework) and games made in OpenFL (a high level framework based on Lime). This pattern likely repeats with many other game engines and technologies.
 
 So please note these limitations any time you use this data for anything important.
 


### PR DESCRIPTION
The link to an example engine, HaxeFlixel, is not using an absolute path so GitHub tries to link it to a (non-existent) file in this repo instead.