### PR TITLE
added iZotope's SDK

### DIFF
--- a/descriptions/SDK.iZotope.md
+++ b/descriptions/SDK.iZotope.md
@@ -1,0 +1,1 @@
+[**iZotope**](https://www.izotope.com/) is an audio technology company who creates various plugins for use in music creation and playback. One of these such plugins can be used with Wwise, another SDK.

--- a/rules.ini
+++ b/rules.ini
@@ -155,6 +155,7 @@ FMOD = (?:^|/)(?:lib)?fmod(?:l|ex|exl|studio|studiol|)(?:64)?\.(?:dylib|dll|so)$
 Greenworks = (?:^|/)greenworks-(?:win|osx|linux)(?:32|64)?\.node$
 Intel_OID = (?:^|/)OpenImageDenoise\.dll$
 Intel_XeSS = (?:^|/)(?:ig|lib)xess\.dll$
+iZotope = (?:^|/)iZotope\.dll$
 JVM = (?:^|/)bin/java(?:\.exe|\.dll)?$
 NodeJS = (?:^|/)node\.dll$
 NVIDIA_Ansel = (?:^|/)AnselSDK(?:32|64)\.dll$

--- a/tests/types/SDK.iZotope.txt
+++ b/tests/types/SDK.iZotope.txt
@@ -1,0 +1,4 @@
+/iZotope.dll
+iZotope.dll
+MultiVersus/Plugins/Wwise/ThirdParty/x64_vc160/Release/bin/iZotope.dll
+The Architect Paris_Data/Plugins/x86_64/iZotope.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -627,6 +627,9 @@ sub/dir/com.rlabrecque.steamworks.net.dllwhoops
 somefile.kpfwhoops
 somefilekpf
 somefile_kpf
+iSotope.dll
+DATA/audio/Wwise 2016.1.0.5775/Authoring/Help/iZotope_HybridReverb.pdf
+Izotope.exe
 bink2w64.ddl
 notabink.dll
 binkw23.dll


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this
https://steamdb.info/app/883710/
https://steamdb.info/app/1525621/
https://steamdb.info/app/1818750/
https://steamdb.info/app/1120480/

I did also find https://steamdb.info/app/939510/, which seems to be a weirder case, as it's literally bundling some of the iZotope plugins you're supposed to make music with, not bundle in games as a dll.
### Brief explanation of the change
Added the iZotope SDK. I would say this is fairly noteworthy; if Wwise itself is in here, and games like Resident Evil 2/3 use this as a standalone SDK, it should be well-known enough.


