### PR TITLE
Add Diesel

### DIFF
--- a/descriptions/Engine.Diesel.md
+++ b/descriptions/Engine.Diesel.md
@@ -1,0 +1,1 @@
+[**Diesel**](https://en.wikipedia.org/wiki/Diesel_(game_engine)) is a game engine developed by Grin and first used in the game Ballistics, released in 2001.

--- a/rules.ini
+++ b/rules.ini
@@ -52,6 +52,7 @@ CryEngine[] = (?:^|/)CryRenderD3D1[12]\.dll$
 CryEngine[] = (?:^|/)CryRenderVulkan\.dll$
 Danmakufu = (?:^|/)th_dnh\.def$
 Defold = (?:^|/)game\.dmanifest$
+Diesel = ^dieselx\.cfg$
 Flexi = (?:^|/)fx_core\.dll$
 FNA = (?:^|/)fna\.dll$
 Frostbite = (?:^|/)(?:Engine\.BuildInfo(?:_Win(?:64|32)_retail(?:_dll)?)?)\.dll$

--- a/tests/types/Engine.Diesel.txt
+++ b/tests/types/Engine.Diesel.txt
@@ -1,0 +1,1 @@
+dieselx.cfg

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -439,6 +439,9 @@ gamexdmanifest
 game.dmanifestfdfd
 pfdfdfgame.gmanifest
 Sub/Folder/game.dmanifestfdfdfdf
+dieselx_cfg
+dieselx.cf
+ieselx.cfg
 Plugins/discordzz-rpc.dll
 discord-rpc.dlll
 Plugins/discord_gamezzz_sdk.dll


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this
https://steamdb.info/app/21680
https://steamdb.info/app/218620/
https://steamdb.info/app/414740/
### Brief explanation of the change
Add Diesel as a game engine
closes #175 
this one misses 2 games that aren't really easy to detect so i'll open an issue about them ([Tom Clancy's Ghost Recon: Advanced Warfighter](https://steamdb.info/app/13640/) & [Tom Clancy's Ghost Recon: Advanced Warfighter 2](https://steamdb.info/app/13510/))
