### PR TITLE
Add UnityCrashHandler executables to Engine.Unity.txt and rules.ini

### DIFF
--- a/rules.ini
+++ b/rules.ini
@@ -123,6 +123,7 @@ UbiArtFramework = pc(?:32)?\.ipk$
 UbisoftAnvil = (?:^|/)(?:datapc(?:64)?|gamedatapc_00)\.forge$
 Unigine = (?:^|/)(?:|lib)Unigine_x(?:86|64)\.(?:dylib|dll|so)$
 Unity[] = (?:^|/)Assembly-CSharp\.dll$
+Unity[] = (?:^|/)UnityCrashHandler(?:32|64)\.exe$
 Unity[] = (?:^|/)Unity(?:Engine|Player)\.(?:dylib|dll)$
 Unity[] = (?:^|/)UnityEngine\..+$
 Unreal[] = (?:^|/)Binaries/Win(?:32|64)/

--- a/tests/types/Engine.Unity.txt
+++ b/tests/types/Engine.Unity.txt
@@ -1,4 +1,5 @@
 /Assembly-CSharp.dll
+/UnityCrashHandler64.exe
 /UnityEngine.@
 /UnityEngine.@@
 /UnityEngine.dll
@@ -12,6 +13,7 @@ Sub/Folder/UnityEngine.dll
 Sub/Folder/UnityEngine.dylib
 Sub/Folder/UnityPlayer.dll
 Sub/Folder/UnityPlayer.dylib
+UnityCrashHandler64.exe
 UnityEngine.@
 UnityEngine.@@
 UnityEngine.CoreModule.dll

--- a/tests/types/Engine.Unity.txt
+++ b/tests/types/Engine.Unity.txt
@@ -1,5 +1,6 @@
 /Assembly-CSharp.dll
 /UnityCrashHandler64.exe
+/UnityCrashHandler32.exe
 /UnityEngine.@
 /UnityEngine.@@
 /UnityEngine.dll
@@ -14,6 +15,7 @@ Sub/Folder/UnityEngine.dylib
 Sub/Folder/UnityPlayer.dll
 Sub/Folder/UnityPlayer.dylib
 UnityCrashHandler64.exe
+UnityCrashHandler32.exe
 UnityEngine.@
 UnityEngine.@@
 UnityEngine.CoreModule.dll


### PR DESCRIPTION
### SteamDB app page links to a few games using this
## UnityCrashHandler64.exe
https://steamdb.info/app/1158770/
https://steamdb.info/app/1013950/
https://steamdb.info/app/1064590/
https://steamdb.info/app/590280/
https://steamdb.info/app/1647160/
https://steamdb.info/app/2102020/
https://steamdb.info/app/240720/
https://steamdb.info/app/535930/
https://steamdb.info/app/573320/

## UnityCrashHandler32.exe
https://steamdb.info/app/706990/
https://steamdb.info/app/1065670/
https://steamdb.info/app/786680/
https://steamdb.info/app/1917090/
https://steamdb.info/app/1128480/
https://steamdb.info/app/758530/
https://steamdb.info/app/1241700/
https://steamdb.info/app/849680/
https://steamdb.info/app/1820170/

##Both
https://steamdb.info/app/1680550/

### Brief explanation of the change
These are files that are found in some Unity games.