### PR TITLE
Add support for detecting EngineX, used by many 2001+ Eurocom games

### DIFF
--- a/descriptions/Engine.EngineX.md
+++ b/descriptions/Engine.EngineX.md
@@ -1,0 +1,1 @@
+[**EngineX**](https://sphinxandthecursedmummy.fandom.com/wiki/EngineX) is an in-house engine of the late Eurocom Entertainment Software and its derived games.

--- a/descriptions/Engine.EngineX.md
+++ b/descriptions/Engine.EngineX.md
@@ -1,1 +1,1 @@
-[**EngineX**](https://sphinxandthecursedmummy.fandom.com/wiki/EngineX) is an in-house engine of the late Eurocom Entertainment Software and its derived games.
+[**EngineX**](https://sphinxandthecursedmummy.fandom.com/wiki/EngineX) is a versatile in-house engine from the late Eurocom Entertainment Software, originally created for Sphinx and the Cursed Mummy.

--- a/rules.ini
+++ b/rules.ini
@@ -58,6 +58,7 @@ CryEngine[] = (?:^|/)CryRenderVulkan\.dll$
 Danmakufu = (?:^|/)th_dnh\.def$
 Defold = (?:^|/)game\.dmanifest$
 Diesel = ^dieselx\.cfg$
+EngineX = ^(?:_bin_PC/BuildData|data)/FILELIST.BIN$
 Flexi = (?:^|/)fx_core\.dll$
 FNA = (?:^|/)fna\.dll$
 Frostbite = (?:^|/)(?:Engine\.BuildInfo(?:_Win(?:64|32)_retail(?:_dll)?)?)\.dll$

--- a/tests/types/Engine.EngineX.txt
+++ b/tests/types/Engine.EngineX.txt
@@ -1,0 +1,2 @@
+data/Filelist.bin
+_bin_PC/BuildData/Filelist.bin


### PR DESCRIPTION
### SteamDB app page links to a few games using this
* [*Sphinx and the Cursed Mummy*](https://steamdb.info/app/606710/)
* [*Pirates of the Caribbean: At World's End*](https://steamdb.info/app/301980/)
* [*G-Force*](https://steamdb.info/app/319170/)
* [*Beijing 2008*](https://steamdb.info/app/10520/)
* [*Vancouver 2010*](https://steamdb.info/app/34180/)
* [*Disney Universe*](https://steamdb.info/app/316260/)
* [*007 Legends*](https://steamdb.info/app/211670/)

### Brief explanation of the change
Add support for detecting EngineX, used by many 2001+ Eurocom games, from Pirates of the Caribbean, to 007, to adventure games like G-Force, Robots (2005), and Sphinx and the Cursed Mummy as well as Olympic games.

https://sphinxandthecursedmummy.fandom.com/wiki/EngineX

### RegExr test filenames
```
data/Filelist.bin
_bin_PC/BuildData/Filelist.bin
_bin_PC/BuildData/Filelist.cfi
PCAudio.dll
```

Some other unique files worth scanning for: `PCGamePadDB.dll`, `PCXMLParser.dll`, `DATA/filelist.000`.