### PR TITLE
Glyph

### DIFF
--- a/descriptions/Launcher.Glyph.md
+++ b/descriptions/Launcher.Glyph.md
@@ -1,0 +1,1 @@
+Glyph is a launcher by [**GAMIGO GROUP**](https://gamigo.com/) for their games.

--- a/rules.ini
+++ b/rules.ini
@@ -226,6 +226,7 @@ ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]
 EA_App = (?:^|/)EAappInstaller\.exe$
+Glyph = (?:^|/)Glyph(?:^|/)\.(?:cfg|exe|xml)$
 MyGames = (?:^|/)GameCenterDistribs\.xml$
 Rockstar = (?:^|/)Rockstar-Games-Launcher\.exe$
 Ubisoft[] = (?:^|/)UbisoftConnectInstaller\.exe$

--- a/rules.ini
+++ b/rules.ini
@@ -226,7 +226,7 @@ ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]
 EA_App = (?:^|/)EAappInstaller\.exe$
-Glyph = (?:^|/)Glyph(?:Client|ClientApp|CrashHandler|Downloader|Downloader)\.(?:cfg|exe|xml)$
+Glyph = (?:^|/)Glyph(?:Client|ClientApp|CrashHandler|Downloader|Downloader|Uninstall||Library|Script|CrashHandler64)\.(?:cfg|exe|xml)$
 MyGames = (?:^|/)GameCenterDistribs\.xml$
 Rockstar = (?:^|/)Rockstar-Games-Launcher\.exe$
 Ubisoft[] = (?:^|/)UbisoftConnectInstaller\.exe$

--- a/rules.ini
+++ b/rules.ini
@@ -226,7 +226,7 @@ ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]
 EA_App = (?:^|/)EAappInstaller\.exe$
-Glyph = (?:^|/)Glyph(?:^|/)\.(?:cfg|exe|xml)$
+Glyph = (?:^|/)GlyphClient\.(?:cfg|exe|xml)$
 MyGames = (?:^|/)GameCenterDistribs\.xml$
 Rockstar = (?:^|/)Rockstar-Games-Launcher\.exe$
 Ubisoft[] = (?:^|/)UbisoftConnectInstaller\.exe$

--- a/rules.ini
+++ b/rules.ini
@@ -226,7 +226,7 @@ ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]
 EA_App = (?:^|/)EAappInstaller\.exe$
-Glyph = (?:^|/)Glyph(?:Client|ClientApp|CrashHandler|Downloader|Downloader|Uninstall||Library|Script|CrashHandler64)\.(?:cfg|exe|xml)$
+Glyph = (?:^|/)Glyph(?:Client|ClientApp|CrashHandler|Downloader|Downloader|Uninstall||Library|Script|CrashHandler64)\.(?:cfg|exe|xml|qml)$
 MyGames = (?:^|/)GameCenterDistribs\.xml$
 Rockstar = (?:^|/)Rockstar-Games-Launcher\.exe$
 Ubisoft[] = (?:^|/)UbisoftConnectInstaller\.exe$

--- a/rules.ini
+++ b/rules.ini
@@ -226,7 +226,7 @@ ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]
 EA_App = (?:^|/)EAappInstaller\.exe$
-Glyph = (?:^|/)GlyphClient\.(?:cfg|exe|xml)$
+Glyph = (?:^|/)Glyph(?:Client|ClientApp|CrashHandler|Downloader|Downloader)\.(?:cfg|exe|xml)$
 MyGames = (?:^|/)GameCenterDistribs\.xml$
 Rockstar = (?:^|/)Rockstar-Games-Launcher\.exe$
 Ubisoft[] = (?:^|/)UbisoftConnectInstaller\.exe$

--- a/rules.ini
+++ b/rules.ini
@@ -226,7 +226,7 @@ ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]
 EA_App = (?:^|/)EAappInstaller\.exe$
-Glyph = (?:^|/)Glyph(?:Client|ClientApp|CrashHandler|Downloader|Downloader|Uninstall||Library|Script|CrashHandler64)\.(?:cfg|exe|xml|qml)$
+Glyph = (?:^|/)Glyph(?:Client|ClientApp|CrashHandler|Downloader|Uninstall|Library|Script|CrashHandler64)\.(?:cfg|exe|xml|qml)$
 MyGames = (?:^|/)GameCenterDistribs\.xml$
 Rockstar = (?:^|/)Rockstar-Games-Launcher\.exe$
 Ubisoft[] = (?:^|/)UbisoftConnectInstaller\.exe$

--- a/rules.ini
+++ b/rules.ini
@@ -226,7 +226,7 @@ ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]
 EA_App = (?:^|/)EAappInstaller\.exe$
-Glyph = (?:^|/)Glyph(?:Client|ClientApp|CrashHandler|Downloader|Uninstall|Library|Script|CrashHandler64)\.(?:cfg|exe|xml|qml)$
+Glyph = ^GlyphClient\.cfg$
 MyGames = (?:^|/)GameCenterDistribs\.xml$
 Rockstar = (?:^|/)Rockstar-Games-Launcher\.exe$
 Ubisoft[] = (?:^|/)UbisoftConnectInstaller\.exe$

--- a/tests/types/Launcher.Glyph.txt
+++ b/tests/types/Launcher.Glyph.txt
@@ -1,2 +1,1 @@
-/GlyphClient.cfg
 GlyphClient.cfg

--- a/tests/types/Launcher.Glyph.txt
+++ b/tests/types/Launcher.Glyph.txt
@@ -1,1 +1,2 @@
 /GlyphClient.cfg
+GlyphClient.cfg

--- a/tests/types/Launcher.Glyph.txt
+++ b/tests/types/Launcher.Glyph.txt
@@ -1,17 +1,1 @@
 /GlyphClient.cfg
-/GlyphClient.exe
-/GlyphClient.xml
-/GlyphClientApp.exe
-/GlyphCrashHandler.exe
-/GlyphDownloader.exe
-/GlyphUninstall.exe
-GlyphClient.cfg
-GlyphClient.exe
-GlyphClient.xml
-GlyphClientApp.exe
-GlyphCrashHandler.exe
-GlyphDownloader.exe
-GlyphUninstall.exe
-Library/GlyphLibrary.xml
-Library/GlyphScript.qml
-x64/GlyphCrashHandler64.exe

--- a/tests/types/Launcher.Glyph.txt
+++ b/tests/types/Launcher.Glyph.txt
@@ -1,0 +1,17 @@
+/GlyphClient.cfg
+/GlyphClient.exe
+/GlyphClient.xml
+/GlyphClientApp.exe
+/GlyphCrashHandler.exe
+/GlyphDownloader.exe
+/GlyphUninstall.exe
+GlyphClient.cfg
+GlyphClient.exe
+GlyphClient.xml
+GlyphClientApp.exe
+GlyphCrashHandler.exe
+GlyphDownloader.exe
+GlyphUninstall.exe
+Library/GlyphLibrary.xml
+Library/GlyphScript.qml
+x64/GlyphCrashHandler64.exe


### PR DESCRIPTION
### SteamDB app page links to a few games using this
https://steamdb.info/depot/845241/


### Brief explanation of the change
Add support for Glyph Launcher. The link above has no information on the Glyph depot itself, but it lists games that use it. many of them are free, so the depot can easily be checked by installing one of them.

