### PR TITLE
rework MyGames rule

### DIFF
--- a/rules.ini
+++ b/rules.ini
@@ -234,7 +234,7 @@ ZStandard = (?:^|/)zstd\.dll$
 [Launcher]
 EA_App = (?:^|/)EAappInstaller\.exe$
 Glyph = ^GlyphClient\.cfg$
-MyGames = (?:^|/)GameCenterDistribs\.xml$
+MyGames = (?:^|/)(?:GameCenter)?Distribs\.xml$
 Rockstar = (?:^|/)Rockstar-Games-Launcher\.exe$
 Ubisoft[] = (?:^|/)UbisoftConnectInstaller\.exe$
 Ubisoft[] = (?:^|/)UplayInstaller\.exe$

--- a/tests/types/Launcher.MyGames.txt
+++ b/tests/types/Launcher.MyGames.txt
@@ -1,2 +1,4 @@
 /GameCenterDistribs.xml
 GameCenterDistribs.xml
+/Distribs.xml
+Distribs.xml


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this

#420 

### Brief explanation of the change

unfortunately, some of the games that are distributed using MyGames launcher (detected by "GameCenterDistribs.xml") have removed "GameCenter" from the file name, that's why i made it optional, this regex might be too broad though, idk

![image](https://github.com/SteamDatabase/FileDetectionRuleSets/assets/81169193/fc0e4889-521e-45b4-a6bc-a65cc2851c2f)


