### PR TITLE
Add DirectStorage as an SDK

### DIFF
--- a/descriptions/SDK.DirectStorage.md
+++ b/descriptions/SDK.DirectStorage.md
@@ -1,0 +1,1 @@
+[**DirectStorage**](https://github.com/microsoft/DirectStorage) is a feature intended to allow games to make full use of high-speed storage (such as NVMe SSDs) that can can deliver multiple gigabytes a second of small data reads with minimal CPU overhead.

--- a/rules.ini
+++ b/rules.ini
@@ -181,6 +181,7 @@ Bink_Video = (?:^|/)bink2?w(?:64|32)?\.dll$
 CEF = (?:^|/)libcef\.(?:dll|so)$
 CRIWARE = \.(?:cpk|sfd|usm|adx|acb|awb)$
 cURL = curl(?:module|lib|d|-4|-ttv|-x64|64|_pluginw64_release)?\.(?:dll|exe|lib|so|so\.4|so\.4\.5\.0)$
+DirectStorage = (?:^|/)dstorage\.dll$
 Discord = (?:^|/)(?:lib)?discord(?:|-rpc|_game_sdk)\.(?:dll|dylib|so)$
 EpicOnlineServices = (?:^|/)(?:lib)?eossdk
 FMOD = (?:^|/)(?:lib)?fmod(?:l|ex|exl|studio|studiol)?(?:64)?\.(?:dylib|dll|so)$

--- a/tests/types/SDK.DirectStorage.txt
+++ b/tests/types/SDK.DirectStorage.txt
@@ -1,0 +1,4 @@
+/dstorage.dll
+Bin64/dstorage.dll
+Engine/Binaries/ThirdParty/Windows/DirectStorage/x64/dstorage.dll
+dstorage.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -585,6 +585,10 @@ Sub/Folder/game.dmanifestfdfdfdf
 dieselx_cfg
 dieselx.cf
 ieselx.cfg
+d.dll
+storage.dll
+dstorage_dll
+dstorage.dl
 Plugins/discordzz-rpc.dll
 discord-rpc.dlll
 Plugins/discord_gamezzz_sdk.dll


### PR DESCRIPTION
### SteamDB app page links to a few games using this
https://steamdb.info/app/2195250/
https://steamdb.info/app/1895880/
https://steamdb.info/app/1680880/
### Brief explanation of the change
Add DirectStorage as an SDK
Closes #445
i'm not a fan of linking to a github repo, i'll have to look if they don't have a website with more info
