### PR TITLE
Add Clickteam Fusion to KNOWN_UNDETECTIONS.md

### DIFF
--- a/KNOWN_UNDETECTIONS.md
+++ b/KNOWN_UNDETECTIONS.md
@@ -6,6 +6,10 @@
 
 HaxeFlixel is one of the most popular engines built on Lime/OpenFL but gives off no particular signal of its own. The best we can do is detect Lime/OpenFL.
 
+### Clickteam Fusion
+
+Many Clickteam Fusion games are packaged as standalone executables with no supporting files.
+
 ### Construct
 
 We detect Construct games based on the presence of a particular JS file. However, it is possible to package all the content in a package.nw file, which hides this information from us and makes it indistinguishable from a generic Node.JS game. The best we can do for these missing cases is detect NodeJS.


### PR DESCRIPTION
### SteamDB app page links to a few games using this
https://steamdb.info/app/2084620/
https://steamdb.info/app/1083480/
https://steamdb.info/app/952330/
https://steamdb.info/app/2061580/
https://steamdb.info/app/1117420/
https://steamdb.info/app/2166200/
https://steamdb.info/app/1275210/
https://steamdb.info/app/710550/
https://steamdb.info/app/1782940/
https://steamdb.info/app/1213460/
https://steamdb.info/app/2333820/
https://steamdb.info/app/298180/
https://steamdb.info/app/2545810/
https://steamdb.info/app/427920/
https://steamdb.info/app/763610/
https://steamdb.info/app/1279000/
https://steamdb.info/app/1384400/
https://steamdb.info/app/713540/
https://steamdb.info/app/702150/
https://steamdb.info/app/930310/
https://steamdb.info/app/1683890/
https://steamdb.info/app/2233040/
https://steamdb.info/app/1394370/
https://steamdb.info/app/1694720/
https://steamdb.info/app/871720/

### Brief explanation of the change
This is only a documentation change, so I've listed some undetected Clickteam Fusion games.