### PR TITLE
Add Return 2 Games Launcher

### DIFF
--- a/descriptions/Launcher.Return_2_Games.md
+++ b/descriptions/Launcher.Return_2_Games.md
@@ -1,0 +1,1 @@
+[**Return 2 Games**](https://return2games.com/) launcher by [**Thing Trunk**](https://thingtrunk.com/) for their Return 2 Games series.

--- a/rules.ini
+++ b/rules.ini
@@ -318,6 +318,7 @@ Gaijin = (?:^|/)gaijin_downloader\.exe$
 Glyph = ^GlyphClient\.cfg$
 MyGames = ^(?:GameCenter)?_chromeresources
 Paradox_Launcher = (?:^|/)dowser\.exe$
+Return_2_Games = (?:^|/)r2g_launcher(?:_2)?\.xml$
 Rockstar = (?:^|/)Rockstar-Games-Launcher\.exe$
 Ubisoft[] = (?:^|/)UbisoftConnectInstaller\.exe$
 Ubisoft[] = (?:^|/)UplayInstaller\.exe$

--- a/tests/types/Engine.Warp.txt
+++ b/tests/types/Engine.Warp.txt
@@ -1,1 +1,0 @@
-assets.wpak

--- a/tests/types/Engine.Warp.txt
+++ b/tests/types/Engine.Warp.txt
@@ -1,0 +1,1 @@
+assets.wpak

--- a/tests/types/Launcher.Return_2_Games.txt
+++ b/tests/types/Launcher.Return_2_Games.txt
@@ -1,0 +1,2 @@
+r2g_launcher.xml
+r2g_launcher_2.xml


### PR DESCRIPTION
### SteamDB app page links to a few games using this
 - [Book of Demons](https://steamdb.info/app/449960/)
 - [HELLCARD: Prologue](https://steamdb.info/app/2207480/)
 - [HELLCARD](https://steamdb.info/app/1201540/)
 - [Book of Aliens](https://steamdb.info/app/1196230/)

### Brief explanation of the change
Add Return 2 Games Launcher. Find r2g_launcher.xml.