### PR TITLE
Add raylib Framework

### DIFF
--- a/descriptions/Engine.raylib.md
+++ b/descriptions/Engine.raylib.md
@@ -1,0 +1,1 @@
+[**raylib**](https://www.raylib.com/) is a simple and easy-to-use library to enjoy videogames programming. raylib is lightweight, multi-platform, free and open-source.

--- a/rules.ini
+++ b/rules.ini
@@ -134,6 +134,7 @@ Prism3D[] = (?:^|/)base\.scs$
 Prism3D[] = (?:^|/)p3shared\.dll$
 PyGame = (?:^|/)pygame
 Rayne = (?:^|/)Rayne\.dll$
+raylib = (?:^|/)(?:lib)?raylib\.(?:dll|so)$
 RealVirtuality[] = \.pbo$
 RealVirtuality[] = \.bisign$
 REDengine = \.(?:red|w2)scripts$

--- a/tests/types/Engine.raylib.txt
+++ b/tests/types/Engine.raylib.txt
@@ -1,0 +1,9 @@
+/raylib.dll
+/raylib.so
+/libraylib.dll
+/libraylib.so
+Sub/Folder/raylib.dll
+raylib.dll
+raylib.so
+libraylib.dll
+libraylib.so

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -773,6 +773,8 @@ sli.spk
 packs/sli
 sdl2xdll
 sdlxdll
+raylib.dllwhoops
+Sub/Folder/raylib.dllwhoops
 nodexdll
 nw.dlls
 nwjs-win/nwxdll


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this

raylib is a small framework and most games could link it statically into executable, making it difficult to detect games using it. Here it is a list of Steam games made with raylib:

 - https://store.steampowered.com/app/1861500/Pure_Logic/
 - https://store.steampowered.com/app/2077590/Sidestep_Legends/
 - https://store.steampowered.com/app/2591410/Moose_Miners/
 - https://store.steampowered.com/app/2781210/CAT__ONION/
 - https://store.steampowered.com/app/2490690/Jump_Tracks/
 - https://store.steampowered.com/app/2229320/Pulse_Codex_EP/
 - https://store.steampowered.com/app/2821220/Space_Mergers/
 - https://store.steampowered.com/app/2678140/YCOM/
 - https://store.steampowered.com/app/2812540/PalmRide_After_Flight/
 - https://store.steampowered.com/app/2751370/Bitty_Knight/
 - https://store.steampowered.com/app/1661930/Y_The_Game/
 - https://store.steampowered.com/app/2697380/Arsenal/
 - https://store.steampowered.com/app/2349850/Lennod_Jump_Game/
 - https://store.steampowered.com/app/2366410/rTexViewer/ - raylib technologies
 - https://store.steampowered.com/app/2377030/rTexPacker/ - raylib technologies
 - https://store.steampowered.com/app/2513200/Mystic_Land_The_Search_for_Maphaldo/
 - https://store.steampowered.com/app/2797670/Rogueborne_Fury/ 

### Brief explanation of the change

Added raylib framework for detection of `raylib.dll` or `libraylib.so`.
