### PR TITLE
update SDK.UnityEntities rule

### DIFF
--- a/rules.ini
+++ b/rules.ini
@@ -304,6 +304,7 @@ trueSKY = (?:^|/)TrueSky(?:PluginRender_MT|PluginRender_MD|UI_MD)\.dll$
 UnityBurst = (?:^|/)lib_burst_generated\.(?:dll|so|bundle)$
 UnityEntities[] = (?:^|/)Unity\.Entities\.dll$
 UnityEntities[] = (?:^|/)StreamingAssets/SubScenes/
+UnityEntities[] = (?:^|/)StreamingAssets/EntityScenes/
 UnityHDRP = (?:^|/)Unity\.RenderPipelines\.HighDefinition\.(?:Config\.Runtime|Runtime)\.dll$
 UnityHybridRenderer = (?:^|/)Unity\.Rendering\.Hybrid\.dll$
 UnityURP = (?:^|/)Unity\.RenderPipelines\.Universal\.Runtime\.dll$

--- a/tests/types/SDK.UnityEntities.txt
+++ b/tests/types/SDK.UnityEntities.txt
@@ -1,4 +1,6 @@
 /StreamingAssets/SubScenes/
+/StreamingAssets/EntityScenes/
 /Unity.Entities.dll
 StreamingAssets/SubScenes/
+StreamingAssets/EntityScenes/
 Unity.Entities.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -162,6 +162,7 @@ SuperUnity.Entities.dll
 Unity.Entitie.dll
 Unity_Entities_dll
 StreamingAssets/Scenes/
+StreamingAssets/EntityScene/
 notGFSDK_TXAA
 GFSDK_AATX
 GFSDK_TAXA
@@ -172,6 +173,7 @@ TrueSkyPluginRender_MT.dl
 rueSkyPluginRender_MT.dll
 TrueSkyPluginRender_MT_dll
 StreamingSets/SubScenes/
+StreamingAsset/EntityScenes/
 Unity.Rendering.Hybrid.dlll
 SuperUnity.Rendering.Hybrid.dll
 Unity.Rendering.Hybrids.dll


### PR DESCRIPTION
### SteamDB app page links to a few games using this

https://steamdb.info/app/2162310/
https://steamdb.info/app/2132350/
https://steamdb.info/app/2783610/

### Brief explanation of the change

`StreamingAssets/SubScenes/` is no longer used in recent versions, `StreamingAssets/EntityScenes/` replaces it.