### PR TITLE
add Crashpad

### DIFF
--- a/descriptions/SDK.Crashpad.md
+++ b/descriptions/SDK.Crashpad.md
@@ -1,0 +1,1 @@
+[**Crashpad**](https://crashpad.chromium.org/) is a crash-reporting system.

--- a/rules.ini
+++ b/rules.ini
@@ -229,6 +229,7 @@ BASS = (?:^|/)(?:bass(?:flac|midi)?\.dll|libbass\.(?:dylib|so))$
 Bink_Video = (?:^|/)bink2?w(?:64|32)?\.dll$
 Box2D = (?:^|/)box2d\.(?:(?:XNA\.)?dll|txt|wasm)$
 CEF = (?:^|/)libcef\.(?:dll|so)$
+Crashpad = (?:^|/)crashpad_handler\.exe$
 Coherent_Gameface_OR_Prysm = (?:^|/)cohtml\.windowsdesktop\.dll$
 CRIWARE = \.(?:cpk|sfd|usm|adx|acb|awb)$
 cURL = curl(?:module|lib|d|-4|-ttv|-x64|64|_pluginw64_release)?\.(?:dll|exe|lib|so|so\.4|so\.4\.5\.0)$

--- a/tests/types/SDK.Crashpad.txt
+++ b/tests/types/SDK.Crashpad.txt
@@ -1,0 +1,2 @@
+/crashpad_handler.exe
+crashpad_handler.exe


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this

- [Sky: Children of the Light](https://steamdb.info/app/2325290/)
 
### Brief explanation of the change

Crashpad is a very popular crash report system made by google, a lot of apps would utilize it as a [backtrace](https://support.backtrace.io/hc/en-us/articles/360040516131-Crashpad-Integration-Guide) integration, like Sky does, but it's still it's own thing.
