### PR TITLE
Add XTrap AntiCheat

### DIFF
--- a/descriptions/AntiCheat.XTrap.md
+++ b/descriptions/AntiCheat.XTrap.md
@@ -1,0 +1,1 @@
+[**XTrap**](https://wiselogic.co.kr/?ckattempt=1#xtrapsection) is an anti-cheating program created and maintained by WiseLogic.

--- a/rules.ini
+++ b/rules.ini
@@ -212,6 +212,8 @@ PunkBuster[] = (?:^|/)Punkbuster(?:$|/)
 Ricochet = (?:^|/)Randgrid\.sys$
 TenProtect = (?:^|/)TP3Helper\.exe$
 XIGNCODE3 = \.xem$
+XTrap[] = (?:^|/)xtrap/
+XTrap[] = (?:^|/)XPva0[123]\.dll$
 
 [SDK]
 Adobe_Flash[] = (?:^|/)Flash[ _]?Player(?:$|/|\.)

--- a/tests/types/AntiCheat.XTrap.txt
+++ b/tests/types/AntiCheat.XTrap.txt
@@ -1,0 +1,8 @@
+/XPva01.dll
+/XPva02.dll
+/XPva03.dll
+/XTrap/
+XPva01.dll
+XPva02.dll
+XPva03.dll
+XTrap/

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -1131,6 +1131,7 @@ GameCenterDistribs.xm
 GameCenterDistribs_xml
 greenworks
 abcgreenworks-win32.node
+xtrap
 /files/gamecore/projectiletypes/_e_rpggrenade_d.dds
 files_gamecore_projectiletypes_e_rpggrenade_d.dds
 files/gamecore/blah


### PR DESCRIPTION
### SteamDB app page links to a few games using this
- [Lost Saga North America](https://steamdb.info/app/266150)
- [Grand Chase](https://steamdb.info/app/304270)
- [Hazard Ops](https://steamdb.info/app/319150)
- [Brick-Force](https://steamdb.info/app/335330)
- [Kalonline](https://steamdb.info/app/475100)
- [Granado Espada](https://steamdb.info/app/319730)
- [Metro Conflict](https://steamdb.info/app/356640)
- [GrandChase Classic](https://steamdb.info/app/1677470)

### Brief explanation of the change
Find XTrap folder and some dlls that I found the attached bitmaps in.
[xpva00.zip](https://github.com/SteamDatabase/FileDetectionRuleSets/files/15179043/xpva00.zip)
