### PR TITLE
add Halley

### DIFF
--- a/descriptions/Engine.Halley.md
+++ b/descriptions/Engine.Halley.md
@@ -1,0 +1,1 @@
+[**Halley**](https://github.com/amzeratul/halley) is a lightweight game engine written in C++17. It has been used to ship Wargroove, a turn-based strategy game, on Windows, Mac (experimental), Nintendo Switch, Xbox One and PS4 (with experimental Android and iOS ports WIP).

--- a/rules.ini
+++ b/rules.ini
@@ -104,6 +104,7 @@ GZDoom[] = (?:^|/)zmusic\.dll$
 GZDoom[] = (?:^|/)gzdoom\.pk3$
 GZDoom[] = (?:^|/)gzdoom\.sf2$
 HaemimontSol = ^Local/English\.hpk$
+Halley = ^assets/config\.dat$
 HashLink = (?:^|/)libhl\.(?:dll|so)$
 idTech[] = (?:^|/)gl(?:quake|hexen)(?:$|/)
 idTech[] = (?:^|/)baseq2(?:$|/)

--- a/tests/types/Engine.Halley.txt
+++ b/tests/types/Engine.Halley.txt
@@ -1,0 +1,1 @@
+assets/config.dat


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this

- [Wargroove](https://steamdb.info/app/607050/)
- [Wargroove 2](https://steamdb.info/app/1346020/)
- [Wargroove 2 Demo](https://steamdb.info/app/2358940/)

### Brief explanation of the change

added a rule for an engine that powers (newer) games by [Chucklefish Games](https://chucklefish.org/). their upcoming game might also be Halley, but I have no information bout that unfortunately.