### PR TITLE
Update CRIWARE Unity detection

### DIFF
--- a/rules.ini
+++ b/rules.ini
@@ -249,6 +249,7 @@ CEF = (?:^|/)libcef\.(?:dll|so)$
 Coherent_Gameface_OR_Prysm = (?:^|/)cohtml\.windowsdesktop\.dll$
 CRIWARE[] = (?:^|/)data(?:1|000)?\.cpk$
 CRIWARE[] = \.(?:sfd|usm|adx|acb|awb)$
+CRIWARE[] = (?:^|/)cri_ware_unity\.dll$
 cURL = curl(?:module|lib|d|-4|-ttv|-x64|64|_pluginw64_release)?\.(?:dll|exe|lib|so|so\.4|so\.4\.5\.0)$
 DirectStorage = (?:^|/)dstorage\.dll$
 Discord = (?:^|/)(?:lib)?discord(?:|-rpc|_game_sdk)\.(?:dll|dylib|so)$

--- a/tests/types/SDK.CRIWARE.txt
+++ b/tests/types/SDK.CRIWARE.txt
@@ -14,6 +14,7 @@
 /data000.cpk
 /data1.cpk
 /resource/gd_PC/e2egreen.sfd
+EleBall_Data/Plugins/x86_64/cri_ware_unity.dll
 N1_Op_TitleLogo_ENG.usm
 data.cpk
 data000.cpk

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -1084,6 +1084,7 @@ BlendThum.dll
 BlendThumb.dlll
 gmv_sp_000.usn
 /data/launch/data1.xcpk
+iwillcri_ware_unity.dll
 C05_010_S010_gdm.awboops
 common_rpf
 SteamChoiceScript-Info_plist


### PR DESCRIPTION
### SteamDB app page links to a few games using this

https://steamdb.info/app/2243710/
https://steamdb.info/app/2985890/
https://steamdb.info/app/2512840/

### Brief explanation of the change

Find cri_ware_unity.dll - the DLL used by the official CRIWARE Unity plugin.
