### PR TITLE
Add EntisGLS engine

### DIFF
--- a/descriptions/Engine.EntisGLS.md
+++ b/descriptions/Engine.EntisGLS.md
@@ -1,0 +1,1 @@
+EntisGLS is a freeware game engine used primarily for creating visual novels and other interactive media.

--- a/rules.ini
+++ b/rules.ini
@@ -78,6 +78,7 @@ Divinity_Engine = ^Data/Localization/language\.lsx$
 Eclipse_Engine[] = ^data\.pie$
 Eclipse_Engine[] = ^Bundle/bundleMain\.mbundle$
 EngineX = ^(?:_bin_PC/BuildData|data)/FILELIST.BIN$
+EntisGLS = ^ending\.noa$
 Essence_Engine = \.sga$
 FalcoEngine = (?:^|/)FalcoEngine\.dll$
 Fase = ^faseEngine\.dll$

--- a/tests/types/Engine.EntisGLS.txt
+++ b/tests/types/Engine.EntisGLS.txt
@@ -1,0 +1,1 @@
+ending.noa

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -964,6 +964,11 @@ Binaries/amd_ags_x64.dlll
 Dll/x64/PhisX_64.dll
 PysXCore.dll
 equ8_db
+ending_noa
+notactuallyending.noa
+ending.noawhoops
+sub/dir/notactuallyending.noa
+sub/dir/ending.noawhoops
 totallynotequ8_conf.json
 sub/dir/equ8.jsondblol
 ring/bin/allegro-5.2.dlll


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this
- [Primal Hearts](https://steamdb.info/depot/1359401/)
- [I Walk Among Zombies Vol. 0](https://steamdb.info/depot/1132721/)
- [I Walk Among Zombies Vol. 1 (Adult Version)](https://steamdb.info/depot/942851/)
- [I Walk Among Zombies Vol. 2 (Adult Version)](https://steamdb.info/depot/1100801/)
- [I Walk Among Zombies Vol. 3](https://steamdb.info/depot/1131551/)

### Brief explanation of the change

Add support for EntisGLS, a visual novel engine. The matching filename for the listed games is `ending.noa`. However, the following are just as valid:
1. bg.noa
2. bgm.noa
3. bs.noa
4. ev.noa
5. movie.noa
6. script.noa
7. se.noa
8. system.noa
9. voice.noa

### Credits

Thanks to VNDB.org for compiling a list of visual novels that use the EntisGLS engine, which can be found [here](https://vndb.org/r?f=fwEntisGLS-).