### PR TITLE
Add E-mote

### DIFF
--- a/descriptions/SDK.E-mote.md
+++ b/descriptions/SDK.E-mote.md
@@ -1,0 +1,1 @@
+[**E-mote**](https://emote.mtwo.co.jp/)  is a Japanese software developed by M2 Co., Ltd. It is primarily used in visual novels to create highly animated and expressive character sprites.

--- a/descriptions/SDK.E-mote.md
+++ b/descriptions/SDK.E-mote.md
@@ -1,1 +1,1 @@
-[**E-mote**](https://emote.mtwo.co.jp/)  is a Japanese software developed by M2 Co., Ltd. It is primarily used in visual novels to create highly animated and expressive character sprites.
+[**E-mote**](https://emote.mtwo.co.jp/) is a Japanese software developed by M2 Co., Ltd. It is primarily used in visual novels to create highly animated and expressive character sprites.

--- a/rules.ini
+++ b/rules.ini
@@ -266,6 +266,7 @@ CRIWARE[] = (?:^|/)cri_ware_unity\.dll$
 cURL = curl(?:module|lib|d|-?[34]|-ttv|-x64|64|_pluginw64_release)?\.(?:dll|exe|lib|so|so\.[34]|so\.[34]\.[0-9]{1,3}\.[0-9]{1,3})$
 DirectStorage = (?:^|/)dstorage\.dll$
 Discord = (?:^|/)(?:lib)?discord(?:|-rpc|_game_sdk)\.(?:dll|dylib|so)$
+E-mote = ^emotedriver\.dll$
 EpicOnlineServices = (?:^|/)(?:lib)?eossdk
 FluidSynth = fluidsynth
 FMOD = (?:^|/)(?:lib)?fmod(?:l|ex|exl|studio|studiol)?(?:64)?\.(?:dylib|dll|so)$

--- a/tests/types/SDK.E-mote.txt
+++ b/tests/types/SDK.E-mote.txt
@@ -1,0 +1,1 @@
+emotedriver.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -905,6 +905,11 @@ Binaries/amd_fidelityfx_vk.dlll
 CryRenderVulkanxdll
 CryD3DCompilerStubxdll
 enginexpak
+emotedriver_dll
+notactuallyemotedriver.dll
+emotedriver.dllwhoops
+sub/dir/notactuallyemotedriver.dll
+sub/dir/emotedriver.dllwhoops
 LICENSExelectronxtxt
 scummvmxexe
 packs/sli_spk


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this

- [NEKOPARA Vol. 0](https://steamdb.info/depot/385801/)
- [NEKOPARA Vol. 1](https://steamdb.info/depot/333601/)
- [NEKOPARA Vol. 2](https://steamdb.info/depot/420111/)
- [NEKOPARA Vol. 3](https://steamdb.info/depot/602521/)
- [NEKOPARA Vol. 4](https://steamdb.info/depot/1406991/)
- [NEKOPARA Extra](https://steamdb.info/depot/899971/)
- [KukkoroDays](https://steamdb.info/depot/1258341/)
- [TroubleDays](https://steamdb.info/depot/1171271/)
- [IdolDays](https://steamdb.info/depot/1576131/)
- [NinNinDays](https://steamdb.info/depot/1075981/)
- [NinNinDays2](https://steamdb.info/depot/1698031/)
- [NekoMiko](https://steamdb.info/depot/969701/)
- [Fantasy Tavern Sextet -Vol.1 New World Days-](https://steamdb.info/depot/1372831/)
- [Fantasy Tavern Sextet -Vol.2 Adventurer's Days-](https://steamdb.info/depot/1461771/)
- [Fantasy Tavern Sextet -Vol.3 Postlude Days-](https://steamdb.info/depot/1523391/)
- [Song of Memories](https://steamdb.info/depot/752572/)
- [Corona Blossom Vol.1 Gift From the Galaxy](https://steamdb.info/depot/496261/)
- [Maitetsu](https://steamdb.info/depot/714801/)
- [Maitetsu:Pure Station](https://steamdb.info/depot/880951/)
- [Maitetsu:Last Run!!](https://steamdb.info/depot/1434481/)
- [Witch's Garden](https://steamdb.info/depot/2347381/)

### Brief explanation of the change
Added "E-mote", a Japanese software developed by M2 Co., Ltd, which is primarily used in visual novels to create highly animated and expressive character sprites. Notable visual novels like Nekopara have used it for their animations.