### PR TITLE
Fix typo in Visual Novel Maker description.

### DIFF
--- a/descriptions/Engine.VisualNovelMaker.md
+++ b/descriptions/Engine.VisualNovelMaker.md
@@ -1,2 +1,2 @@
 [Visual Novel Maker](https://visualnovelmaker.com/) is a multi-platform, point-and-click
-engine by Degica for creaitng visual novels without the need for any programming.
+engine by Degica for creating visual novels without the need for any programming.


### PR DESCRIPTION
### Brief explanation of the change

Corrected a typo in the description ('creaitng' to 'creating').