### PR TITLE
Yarn Spinner detection if IL2CPP is also used

### DIFF
--- a/rules.ini
+++ b/rules.ini
@@ -359,7 +359,7 @@ Wwise[] = (?:^|/)Ak(?:Unity)?SoundEngine(?:dll)?\.(?:bundle|dll)$
 Wwise[] = (?:^|/)WwiseGDNative\.dll$
 XAudio2 = (?:^|/)xaudio2_9redist\.dll$
 Yarn_Spinner[] = (?:^|/)YarnSpinner\.dll$
-Yarn_Spinner[] = (?:^|/)Yarn\.System\.(?:Buffers|Memory|Numerics\.Vectors)\.dll-resources.dat
+Yarn_Spinner[] = (?:^|/)Yarn\.System\.(?:Buffers|Memory|Numerics\.Vectors)\.dll-resources.dat$
 ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]

--- a/rules.ini
+++ b/rules.ini
@@ -358,7 +358,8 @@ Vorbis = vorbis
 Wwise[] = (?:^|/)Ak(?:Unity)?SoundEngine(?:dll)?\.(?:bundle|dll)$
 Wwise[] = (?:^|/)WwiseGDNative\.dll$
 XAudio2 = (?:^|/)xaudio2_9redist\.dll$
-Yarn_Spinner = Yarn(?:-|_|\s|\.)?(?:Spinner|System)
+Yarn_Spinner[] = (?:^|/)YarnSpinner\.dll$
+Yarn_Spinner[] = (?:^|/)Yarn\.System\.Memory\.dll-resources\.dat$
 ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]

--- a/rules.ini
+++ b/rules.ini
@@ -358,7 +358,8 @@ Vorbis = vorbis
 Wwise[] = (?:^|/)Ak(?:Unity)?SoundEngine(?:dll)?\.(?:bundle|dll)$
 Wwise[] = (?:^|/)WwiseGDNative\.dll$
 XAudio2 = (?:^|/)xaudio2_9redist\.dll$
-Yarn_Spinner = (?:^|/)YarnSpinner\.dll$
+Yarn_Spinner[] = (?:^|/)YarnSpinner\.dll$
+Yarn_Spinner[] = (?:^|/)Yarn\.System\.(?:Buffers|Memory|Numerics\.Vectors)\.dll-resources.dat
 ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]

--- a/rules.ini
+++ b/rules.ini
@@ -358,8 +358,7 @@ Vorbis = vorbis
 Wwise[] = (?:^|/)Ak(?:Unity)?SoundEngine(?:dll)?\.(?:bundle|dll)$
 Wwise[] = (?:^|/)WwiseGDNative\.dll$
 XAudio2 = (?:^|/)xaudio2_9redist\.dll$
-Yarn_Spinner[] = (?:^|/)YarnSpinner\.dll$
-Yarn_Spinner[] = (?:^|/)Yarn\.System\.(?:Buffers|Memory|Numerics\.Vectors)\.dll-resources.dat$
+Yarn_Spinner = Yarn(?:-|_|\s|\.)?(?:Spinner|System)
 ZStandard = (?:^|/)zstd\.dll$
 
 [Launcher]

--- a/tests/types/SDK.Yarn_Spinner.txt
+++ b/tests/types/SDK.Yarn_Spinner.txt
@@ -1,6 +1,4 @@
 /YarnSpinner.dll
 YarnSpinner.dll
 NightInTheWoods_Data/Managed/YarnSpinner.dll
-Night In The Woods_Data/il2cpp_data/Resources/Yarn.System.Numerics.Vectors.dll-resources.dat
 Night In The Woods_Data/il2cpp_data/Resources/Yarn.System.Memory.dll-resources.dat
-Night In The Woods_Data/il2cpp_data/Resources/Yarn.System.Buffers.dll-resources.dat

--- a/tests/types/SDK.Yarn_Spinner.txt
+++ b/tests/types/SDK.Yarn_Spinner.txt
@@ -1,3 +1,6 @@
 /YarnSpinner.dll
 YarnSpinner.dll
 NightInTheWoods_Data/Managed/YarnSpinner.dll
+Night In The Woods_Data/il2cpp_data/Resources/Yarn.System.Numerics.Vectors.dll-resources.dat
+Night In The Woods_Data/il2cpp_data/Resources/Yarn.System.Memory.dll-resources.dat
+Night In The Woods_Data/il2cpp_data/Resources/Yarn.System.Buffers.dll-resources.dat

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -1344,7 +1344,7 @@ Files/languagebank/english/textfiles/fpsc-050
 Files/languagebank/english/textfiles/notactuallyfpsc-050.ini
 Files/languagebank/english/textfiles/fpsc-050.iniwhoops
 languagebank/english/textfiles/fpsc-050.ini
-YarnSpinnerTest.dll
+Yarn.Test.Spinner.dll
 /Yarn/Spinner
 YarnSpin
 odin_dll


### PR DESCRIPTION
### SteamDB app page links to a few games using this

* [The Berlin Apartment](https://steamdb.info/app/3153440/depots/)
* [Little Nemo and the Guardians of Slumberland ](https://steamdb.info/app/2440530/depots/)

### Brief explanation of the change

If a game is made in Unity and IL2CPP is used, the usual YarnSpinner.dll will not be present. Instead, depending on what parts of Yarn Spinner have been used, new .dat files will be emitted with these patterns.

As Yarn Spinner is primarily an unpaid project, and we use no analytics, getting an accurate read on how many people use the tool is one of our primary ways of keeping track of the project. We are super, super grateful that a tool like SteamDB exists.