### PR TITLE
Add s&box engine

### DIFF
--- a/descriptions/Engine.sandbox.md
+++ b/descriptions/Engine.sandbox.md
@@ -1,0 +1,1 @@
+[**s&box**](https://sbox.game/) is an engine made by Facepunch, built on top of Valve's Source 2.

--- a/rules.ini
+++ b/rules.ini
@@ -182,6 +182,7 @@ RPG_Developer_Bakin = (?:^|/)bakinengine\.dll$
 S2_Engine_HD = (?:^|/)S2Core\.dll$
 SakanaGL[] = (?:^|/)sakanagl\.dll$
 SakanaGL[] = \.sxstorage$
+sandbox = ^sbox-standalone\.dll$
 Serious_Engine = (?:All|01|patch)\.gro$
 ShiVa3D = \.stk$
 Silk = ^packs/sli\.spk$

--- a/tests/types/Engine.sandbox.txt
+++ b/tests/types/Engine.sandbox.txt
@@ -1,0 +1,1 @@
+sbox-standalone.dll

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -1364,3 +1364,5 @@ odin_dll
 libodin_so
 notodin.dll
 notlibodin.so
+notsbox-standalone.dll
+sbox-standaloneadll


### PR DESCRIPTION
<!-- Make sure to check out CONTRIBUTING.md file to see that you've added everything -->

### SteamDB app page links to a few games using this
https://steamdb.info/app/590830/ (s&box itself)
https://steamdb.info/app/3115420/ (My Summer Cottage)

### Brief explanation of the change
Here are some pages that explain the standalone publishing in s&box:
- https://sbox.game/news/august-update-4b1b55d9#standalone-exporting
- https://sbox.game/news/january-update-6a7d5bb1#standalone
- https://sbox.game/dev/doc/

As of writing, Valve is still "checking over" their publishing agreement, and officially standalone publishing is not yet allowed. This is what the editor says:
![2025-07-30_13-58-40](https://github.com/user-attachments/assets/c30c4ea4-f495-48a2-956c-2588ccfaa6d9)

As I understand it, My Summer Cottage has a special deal with Facepunch which allows them to publish regardless.

I understand if you want to hold off on merging this until a few more games join the ranks.