### PR TITLE
Add Zouna game engine

### DIFF
--- a/descriptions/Engine.Zouna.md
+++ b/descriptions/Engine.Zouna.md
@@ -1,0 +1,1 @@
+[**Zouna**](https://www.mobygames.com/group/19209/game-engine-zouna/) is a game engine originally developed by Kalisto Entertainment and used by Asobo Studio, Ubisoft Montreal, Black Sheep Studio, BigSky Interactive, and Wanadoo Edition.

--- a/rules.ini
+++ b/rules.ini
@@ -225,6 +225,8 @@ XNA[] = (?:^|/|\.)XNA(?:$|/|\.)
 XNA[] = \.xnb$
 Xors3D = (?:^|/)Xors3d\.dll$
 YU-RIS = (?:^|/)yscfg\.dat$
+Zouna[] = (?:^|/)DATAS/SHARED\.DPC$
+Zouna[] = (?:^|/)GameData/Bigfiles/PC/P4/MISC\.BFPC$
 
 [Container]
 Electron = (?:^|/)LICENSE\.electron\.txt$

--- a/tests/types/Engine.Zouna.txt
+++ b/tests/types/Engine.Zouna.txt
@@ -1,0 +1,4 @@
+/DATAS/SHARED.DPC
+/GameData/Bigfiles/PC/P4/MISC.BFPC
+DATAS/SHARED.DPC
+GameData/Bigfiles/PC/P4/MISC.BFPC

--- a/tests/types/_NonMatchingTests.txt
+++ b/tests/types/_NonMatchingTests.txt
@@ -1298,6 +1298,12 @@ Binaries/Retail/ooo2core_5_win64.dll
 oo2test_6_win64.dll
 oo2core_7_win64_dll
 oo2core_8_win64.dlll
+/DATAS/SHARED.DPCWHOOPS
+/GameData/Bigfiles/PC/P4/MISC.BFPCWHOOPS
+DATAS/SHARED_DPC
+GameData/Bigfiles/PC/P4/MISC_BFPC
+SHARED_DPC
+MISC_BFPC
 game
 pygam
 data


### PR DESCRIPTION
### SteamDB app page links to a few games using this

https://steamdb.info/app/283410/ - CT Special Forces: Fire for Effect
https://steamdb.info/app/331750/ - WALL E
https://steamdb.info/app/12800/ - FUEL
https://steamdb.info/app/12850/ - FUEL - Demo (FUEL™ Demo)
https://steamdb.info/app/579490/ - RUSH: A Disney • PIXAR Adventure
https://steamdb.info/app/752590/ - A Plague Tale: Innocence
https://steamdb.info/depot/1096661/ - A Plague Tale: Innocence Demo
https://steamdb.info/app/1182900/ - A Plague Tale: Requiem
https://steamdb.info/app/1250410/ - Microsoft Flight Simulator (2020)
https://steamdb.info/app/2537590/ - Microsoft Flight Simulator 2024
https://steamdb.info/app/239220/ - The Mighty Quest For Epic Loot

### Brief explanation of the change

Adds patterns, tests, and a description for the Zouna game engine. The matching files are usually in the main depot for the game, but are sometimes in the language-specific depots. As a bonus, if this gets merged, there will be a game engine for every letter of the alphabet except Q.
